### PR TITLE
fix(ci): release-smoke tolerates private-repo SLSA absence

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -141,8 +141,34 @@ jobs:
           # gh attestation verify reads from the GitHub attestation
           # service. --owner pins the trust root to this org so a
           # malicious lookalike binary fails closed.
-          gh attestation verify artifacts/clockify-mcp-linux-x64 \
-            --owner "${GITHUB_REPOSITORY_OWNER}"
+          #
+          # On user-owned private repositories the attestation
+          # service returns "Feature not available for user-owned
+          # private repositories" (HTTP 404). release.yml's
+          # attest-build-provenance step is continue-on-error for
+          # the same reason (commit 6f4f748), so on that account
+          # tier no attestation is actually produced and verifying
+          # a missing attestation cannot succeed.
+          #
+          # We treat the narrow "feature not available" / HTTP 404
+          # outcome as SKIPPED (::notice::); the two mandatory
+          # cosign checks below still gate the smoke. Every other
+          # failure mode (signature mismatch, missing bundle,
+          # wrong owner, expired root) stays fatal. See
+          # docs/adr/0013-private-repo-slsa-posture.md for rationale.
+          log=$(mktemp)
+          if gh attestation verify artifacts/clockify-mcp-linux-x64 \
+              --owner "${GITHUB_REPOSITORY_OWNER}" >"$log" 2>&1; then
+            cat "$log"
+            exit 0
+          fi
+          cat "$log"
+          if grep -qE 'Feature not available for user-owned private repositor|HTTP 404' "$log"; then
+            echo "::notice title=SLSA attestation skipped::GitHub attestation service is unavailable for user-owned private repositories. cosign blob + image checks remain mandatory. See docs/adr/0013-private-repo-slsa-posture.md."
+            exit 0
+          fi
+          echo "::error::gh attestation verify failed with a non-skippable error. See log above."
+          exit 1
 
       - name: Verify cosign keyless signature on binary
         env:

--- a/docs/adr/0013-private-repo-slsa-posture.md
+++ b/docs/adr/0013-private-repo-slsa-posture.md
@@ -1,0 +1,127 @@
+# 0013 - Private-repo SLSA posture
+
+## Status
+
+Accepted — codifies the release-smoke skip path added alongside
+this ADR and the `continue-on-error` treatment already in
+`release.yml` and `docker-image.yml`.
+
+## Context
+
+`go-clockify` ships three independent supply-chain verifications
+on every release:
+
+1. **SLSA build provenance** via
+   `actions/attest-build-provenance`, verified by
+   `gh attestation verify` at release-smoke time.
+2. **cosign keyless signature on the binary** via goreleaser's
+   `signs.cosign-keyless`, verified by `cosign verify-blob`.
+3. **cosign keyless signature on the multi-arch container
+   image** via `docker-image.yml`, verified by `cosign verify`.
+
+The GitHub build-provenance attestation service is a feature
+whose availability depends on the repository's **account tier**:
+
+- Public repositories — available.
+- Repositories owned by a GitHub organization — available.
+- Repositories owned by a **user account and marked private** —
+  **not available**. `gh attestation verify` returns
+  `Feature not available for user-owned private repositories.`
+  and the server responds with HTTP 404. No amount of retry,
+  propagation wait, or `--owner` trust-root tweaking unblocks
+  this — the attestation is never produced.
+
+`go-clockify` is currently a user-owned private repository.
+Commit [`6f4f748`](https://github.com/apet97/go-clockify/commit/6f4f748)
+already flipped `docker-image.yml`'s attest-build-provenance step
+to `continue-on-error: true` so the per-main-push build pipeline
+does not fail. The release workflow (`release.yml`) carries the
+same `continue-on-error` on its attestation step for the same
+reason.
+
+The gap this ADR closes: **release-smoke** still ran
+`gh attestation verify` as fatal, so every scheduled or
+release-dispatched smoke run failed, opened a
+`release-smoke-failure` issue (#7), and never auto-closed. The
+two mandatory cosign layers — which *do* work on user-owned
+private repos, because they use keyless OIDC, not the
+attestation service — were never reported on because smoke
+exited before it got to them.
+
+## Decision
+
+SLSA build provenance is **optional supply-chain telemetry** for
+this repository at its current account tier. The mandatory
+gate is the two-layer cosign chain (binary + image).
+
+Release-smoke now:
+
+1. Runs `gh attestation verify` in a wrapper that captures its
+   output.
+2. On success — as today — the step passes.
+3. On failure — the wrapper inspects the error:
+   - If the error matches `Feature not available for
+     user-owned private repositor` or `HTTP 404`, the step logs a
+     `::notice::` titled "SLSA attestation skipped" and exits 0.
+   - Every other failure mode (signature mismatch, missing
+     bundle, wrong owner, expired cosign root, tampered
+     binary) stays fatal.
+4. The two cosign checks below remain mandatory — a bad cosign
+   signature on either binary or image still fails the smoke
+   and opens an issue.
+
+The skip is **narrow and explicit**: it fires only on the two
+specific error signatures the attestation service emits when
+the feature gate is off. If GitHub later enables build
+provenance for user-owned private repos, the step will succeed
+and the skip branch becomes dead code — at which point the
+cosign checks continue to gate unchanged.
+
+## Consequences
+
+**Positive.**
+- Release-smoke can now reach a green state without requiring a
+  repository-visibility or ownership change.
+- Issue #7 closes automatically on the next green run instead of
+  lingering as a permanent red flag that nobody actually needs
+  to act on.
+- The two cosign layers, which are the actually-binding
+  cryptographic evidence at this account tier, are no longer
+  masked by the attestation 404.
+
+**Negative / residual.**
+- `go-clockify` releases at this account tier carry two of the
+  three canonical supply-chain attestations, not three. That is
+  a true reduction in evidence compared to a
+  public-or-org-owned repo. The README and
+  `docs/production-readiness.md` should state this plainly to
+  operators who require SLSA provenance specifically.
+- If GitHub changes the exact text of the "feature not
+  available" message, the grep will stop matching and the step
+  will start failing again. The fix is a one-line grep update.
+  Tracked implicitly: any regression will be caught on the next
+  smoke run.
+
+## Upgrade path (third option, not taken today)
+
+Moving `go-clockify` to a public repository or to an
+organization account activates the attestation service. At
+that point:
+
+1. `release.yml`'s attest-build-provenance step stops needing
+   `continue-on-error: true`.
+2. `docker-image.yml`'s attest-build-provenance step stops
+   needing `continue-on-error: true`.
+3. The skip branch added to `release-smoke.yml` becomes dead
+   code but does not need removing — it simply never fires.
+
+That flip is a **product/governance decision**, not a code
+change, and is tracked as a separate backlog issue.
+
+## References
+
+- Commit [`6f4f748`](https://github.com/apet97/go-clockify/commit/6f4f748) —
+  docker-image.yml continue-on-error.
+- `.github/workflows/release-smoke.yml` — skip wrapper.
+- `docs/verification.md` — operator-facing note on manual
+  verification and the skip semantics.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -57,6 +57,19 @@ attestation has not yet propagated through GitHub's storage (this is
 eventually consistent — retry in 10 minutes for a freshly published
 release).
 
+> **Note — user-owned private repositories.** `gh attestation verify`
+> returns "Feature not available for user-owned private repositories"
+> (HTTP 404) when the repository is private and owned by a user
+> account rather than an organization or a public repo. In that
+> account tier the GitHub attestation service is not active, so
+> `release.yml`'s `actions/attest-build-provenance` step runs with
+> `continue-on-error: true` and no attestation is produced. The
+> release-smoke workflow treats this narrow outcome as **skipped**
+> (surfaced as a `::notice::`); the two mandatory cosign checks
+> below remain the gate. See
+> [`docs/adr/0013-private-repo-slsa-posture.md`](adr/0013-private-repo-slsa-posture.md)
+> for the rationale and the upgrade path.
+
 ## 2. Cosign keyless signature on the binary
 
 Goreleaser's `signs.cosign-keyless` step writes a sigstore bundle


### PR DESCRIPTION
## Summary

- `.github/workflows/release-smoke.yml`: classify the "Feature not available for user-owned private repositories" / HTTP 404 response from `gh attestation verify` as **skipped** (`::notice::`), not **failed**. Every other failure class stays fatal. The two mandatory cosign layers below remain the binding gate.
- `docs/verification.md`: add a user-facing note about the skip semantics and account-tier dependency.
- `docs/adr/0013-private-repo-slsa-posture.md`: new ADR codifying the decision, the residual trade-off (two-of-three attestations on user-owned private tier), and the upgrade path (flip to public or org).

## Why

Release-smoke has failed on every scheduled and release-dispatched run (v1.0.0 on 2026-04-13, v1.0.3 on 2026-04-20). The failure is not a signing regression — it's that `gh attestation verify` cannot verify an attestation that never gets produced on this account tier. `release.yml` and `docker-image.yml` already apply `continue-on-error: true` to their `actions/attest-build-provenance` steps for the same reason (commit 6f4f748). Smoke is the last step still treating an absent attestation as fatal.

The consequence: Issue #7 never auto-closes, masking the two cosign layers that do gate the supply chain at this tier.

## Test plan

- [ ] Manual re-run after merge: `gh workflow run release-smoke.yml -f tag=v1.0.3` → passes on the SLSA step with `::notice::`, passes both cosign steps, closes Issue #7.
- [ ] Signature-regression drift check: if cosign verification is broken in the future, smoke still fails fatally (grep is narrow).
- [ ] YAML validated locally: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-smoke.yml'))"` → OK.