### PR TITLE
fix(ci): align release-smoke cosign version with release signer

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -77,7 +77,13 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
-          cosign-release: v2.4.1
+          # Must match release.yml's cosign-release. v2.4.1 verifier
+          # cannot read bundles produced by the v2.4.3 signer — cosign
+          # reports "bundle does not contain cert for verification" on
+          # the newer --new-bundle-format output. Keep both workflows
+          # pinned to the same minor so smoke verifies what release
+          # signed.
+          cosign-release: v2.4.3
 
       - name: Resolve release tag
         id: tag


### PR DESCRIPTION
## Summary

One-line cosign version bump (v2.4.1 → v2.4.3) in release-smoke.yml so the verifier reads what the signer produced. Adds a short comment at the pin to record the invariant.

## Why

The smoke run dispatched against v1.0.3 after PR #16 merged (run 24752920636, 2026-04-22 00:04) failed at "Verify cosign keyless signature on binary" with:

> Error: bundle does not contain cert for verification, please provide public key

Root cause: release.yml signs with cosign v2.4.3 which uses \`--new-bundle-format\` (cert chain embedded in the sigstore bundle). release-smoke was verifying with v2.4.1 which cannot read that bundle format on a \`verify-blob --bundle\` path.

PR #16 fixed the SLSA attestation skip; this closes the second failure the smoke run surfaced. Together they unblock Issue #7.

## Test plan

- [ ] After merge: \`gh workflow run release-smoke.yml -f tag=v1.0.3\` → green.
- [ ] Issue #7 auto-closes on the green run.
- [ ] docker-image.yml still pinned at v2.4.1 — its signing step writes image sigs (not blob bundles), which smoke verifies via \`cosign verify\` (image path, not blob). That step remained green in the latest smoke run, so no change needed there.

## Linked

- Depends on #16 (SLSA skip) being merged — confirmed merged at 8cd21ce.
- Unblocks Issue #7 once this lands and a fresh smoke run passes.