### PR TITLE
fix(ci): release-smoke authenticates to ghcr.io before cosign verify

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -85,6 +85,16 @@ jobs:
           # signed.
           cosign-release: v2.4.3
 
+      - name: Authenticate to ghcr.io
+        # The container image published by docker-image.yml is private
+        # on user-owned repos. cosign triangulate + cosign verify both
+        # need registry auth to read the manifest. The GITHUB_TOKEN has
+        # read:packages via the `packages: read` permission declared at
+        # the top of this workflow.
+        run: echo "${GITHUB_TOKEN}" | cosign login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Resolve release tag
         id: tag
         env:


### PR DESCRIPTION
## Summary

One new step in `release-smoke.yml`: \`cosign login ghcr.io\` using \`GITHUB_TOKEN\`, before the existing \`cosign triangulate\` / \`cosign verify\` steps that read the container-image manifest.

## Why

Issue #7 has been peeled back in layers:
1. **SLSA 404** on user-owned private repos — fixed by #16.
2. **cosign bundle format skew** (v2.4.1 verifier vs v2.4.3 signer) — fixed by #18.
3. **ghcr.io manifest read blocked by missing registry auth** — **this PR**.

Recent smoke run 24754431870 confirmed layers 1 & 2 are resolved (both steps passed); it surfaced layer 3 with \`MANIFEST_UNKNOWN\`. docker-image.yml published the v1.0.3 image cleanly (run 24642812092); the issue is purely about reading it back. User-owned repos ship container images as private by default on ghcr.io, so anonymous reads fail.

The workflow already declares \`packages: read\` at its top; this step just activates that permission via \`cosign login\`.

## Test plan

- [ ] After merge: \`gh workflow run release-smoke.yml -f tag=v1.0.3\` → green.
- [ ] Issue #7 auto-closes on the green run.
- [ ] The three verification steps (SLSA skip, cosign blob, cosign image) all show OK.

## Linked

- Depends on #16 (merged) and #18 (merged).
- Third and — hopefully — final piece for Issue #7.