### PR TITLE
fix(ci): release-smoke strips v-prefix before ghcr manifest lookup

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -208,7 +208,15 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          ref="ghcr.io/${GITHUB_REPOSITORY_OWNER}/go-clockify:${TAG}"
+          # docker-image.yml's metadata-action uses pattern={{version}}
+          # which strips the leading `v` — the ghcr.io image tag is the
+          # bare semver (e.g. 1.0.3), not the git ref (v1.0.3). The
+          # goreleaser sigstore bundles live under the git ref, so the
+          # cosign verify-blob step above keeps the v-prefix; only the
+          # container manifest lookup needs the stripped form. Passing
+          # the raw git tag here produced MANIFEST_UNKNOWN on v1.0.3.
+          image_tag="${TAG#v}"
+          ref="ghcr.io/${GITHUB_REPOSITORY_OWNER}/go-clockify:${image_tag}"
           digest="$(cosign triangulate --type digest "$ref")"
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Strip leading `v` from the release tag before constructing the ghcr.io image reference in `release-smoke.yml` — the docker-image.yml metadata-action publishes semver tags via `pattern={{version}}` (bare `1.0.3`), not `v1.0.3`, so `cosign triangulate` was returning `MANIFEST_UNKNOWN`.
- Keep the sigstore-blob verification step passing the raw git tag; only the container manifest lookup needs the stripped form. A comment at the call site documents the asymmetry.
- Final peel of Issue #7. The previous three remediations (#16 SLSA tolerance, #18 cosign version alignment, #19 ghcr auth) were all correct and necessary — each exposed the next layer.

## Test plan

- [x] Local grep: `gh api /user/packages/container/go-clockify/versions` confirms the ghcr tags are `1.0.0`..`1.0.3`, `latest`, `main` — no `v`-prefixed semver tags.
- [x] Diff limited to one step in one workflow file; shell syntax (`${TAG#v}`) is POSIX parameter expansion.
- [ ] CI (yaml-lint + actionlint) passes.
- [ ] Post-merge: `gh workflow run release-smoke.yml -f tag=v1.0.3` → green; Issue #7 auto-closes via the workflow's "Close stale failure issues on green run" step.

Closes #7.