### PR TITLE
docs(governance): align four docs on single-maintainer reality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,42 +1,50 @@
 # CODEOWNERS — declares review responsibility for go-clockify.
 #
-# This is a single-maintainer project today, so every entry resolves
-# to the same owner. The per-area entries are kept for two reasons:
-#   1. They give a future co-maintainer a clean diff target. Adding
-#      a second handle to one of these lines is a one-line PR.
-#   2. They make ownership *visible* to GitHub's CODEOWNERS UI on
-#      every PR — auditors can see at a glance which directories
-#      route through review.
+# This is a single-maintainer project today (see GOVERNANCE.md); every
+# entry resolves to `@apet97`. The per-area entries are kept for two
+# reasons:
+#   1. They give a future co-maintainer a clean diff target. Adding a
+#      second handle to one of these lines is a one-line PR.
+#   2. They make ownership *visible* to GitHub's CODEOWNERS UI on every
+#      PR — auditors can see at a glance which directories route
+#      through review, even when review is self-review.
+#
+# The former `@backup-maintainer` placeholder was dropped in Wave J
+# (2026-04-22) after a governance audit found it was not a real GitHub
+# handle and contradicted the single-maintainer reality in
+# docs/production-readiness.md and docs/branch-protection.md. See
+# docs/adr/0016-single-maintainer-governance.md for the rationale.
 #
 # See GOVERNANCE.md for the human policy this file implements.
 # See docs/branch-protection.md for the snapshot of GitHub branch
 # protection rules that enforce review-required on main.
 
-*                            @apet97 @backup-maintainer
+*                            @apet97
 
-# Security-sensitive surfaces — tighter expectations from GOVERNANCE.md
-/internal/authn/             @apet97 @backup-maintainer
-/internal/enforcement/       @apet97 @backup-maintainer
-/internal/policy/            @apet97 @backup-maintainer
-/internal/transport/         @apet97 @backup-maintainer
-/internal/clockify/          @apet97 @backup-maintainer
+# Security-sensitive surfaces — tighter self-review expectations from GOVERNANCE.md
+/internal/authn/             @apet97
+/internal/enforcement/       @apet97
+/internal/policy/            @apet97
+/internal/transport/         @apet97
+/internal/clockify/          @apet97
 
 # Operator-facing surfaces
-/cmd/                        @apet97 @backup-maintainer
-/deploy/                     @apet97 @backup-maintainer
+/cmd/                        @apet97
+/deploy/                     @apet97
 
 # Supply chain — release pipeline, CI, dependency manifests
-/.github/                    @apet97 @backup-maintainer
-/.goreleaser.yaml            @apet97 @backup-maintainer
-/scripts/                    @apet97 @backup-maintainer
-/Makefile                    @apet97 @backup-maintainer
-/go.mod                      @apet97 @backup-maintainer
-/go.sum                      @apet97 @backup-maintainer
+/.github/                    @apet97
+/.goreleaser.yaml            @apet97
+/scripts/                    @apet97
+/Makefile                    @apet97
+/go.mod                      @apet97
+/go.sum                      @apet97
 
 # Documentation that operators rely on
-/SECURITY.md                 @apet97 @backup-maintainer
-/GOVERNANCE.md               @apet97 @backup-maintainer
-/docs/release-policy.md      @apet97 @backup-maintainer
-/docs/verification.md        @apet97 @backup-maintainer
-/docs/branch-protection.md   @apet97 @backup-maintainer
-/docs/runbooks/              @apet97 @backup-maintainer
+/SECURITY.md                 @apet97
+/GOVERNANCE.md               @apet97
+/SUPPORT.md                  @apet97
+/docs/release-policy.md      @apet97
+/docs/verification.md        @apet97
+/docs/branch-protection.md   @apet97
+/docs/runbooks/              @apet97

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,13 @@
 ## Description
 
-Brief description of what this PR does.
+Brief description of what this PR does. Focus on the **why** — the
+what is in the diff.
+
+## Merge gate
+
+This PR follows [`GOVERNANCE.md`](../GOVERNANCE.md). Required CI
+checks are documented in
+[`docs/branch-protection.md`](../docs/branch-protection.md).
 
 ## Checklist
 
@@ -8,5 +15,24 @@ Brief description of what this PR does.
 - [ ] `go vet ./...` — no warnings
 - [ ] `go build ./...` — builds successfully
 - [ ] `go test -race ./...` — all tests pass
+- [ ] `make release-check` — green locally (required before push)
 - [ ] Tests added for new functionality
 - [ ] Documentation updated if needed
+
+## Sensitive areas
+
+This PR touches one or more of the paths listed in
+[`GOVERNANCE.md`](../GOVERNANCE.md#tighter-self-review-expectations-on-security-sensitive-areas)
+(`internal/authn/`, `internal/enforcement/`, `internal/policy/`,
+`internal/transport/`, `internal/clockify/`,
+`.github/workflows/release.yml`, `.github/workflows/docker-image.yml`,
+`.goreleaser.yaml`, `deploy/`):
+
+- [ ] Yes — self-review rationale below.
+- [ ] No — this box does not apply.
+
+If **yes**, document the self-review here: which path, what
+changed, how it was validated, and any drift-check or manual
+exercise performed (example: "flipped the expected value in
+`TestFoo_Bar`, confirmed the test fails, restored"). This is the
+written record that Wave J's governance rewrite relies on.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,61 +6,95 @@ to imitate the governance theatre of a large foundation.
 
 ## Project status
 
-`go-clockify` is a **two-maintainer project** today. `@apet97` and `@backup-maintainer`
-author the majority of code, review and merge all pull requests,
-ship releases, and triage security disclosures. There is no
-steering committee, no technical advisory board, no rotating release
-captain. There is no fiction here either — operators can read this
-document, see who is on the hook, and decide whether their risk
-appetite allows depending on it.
+`go-clockify` is a **single-maintainer project today**. `@apet97` is
+the sole maintainer: author of the majority of code, reviewer and
+merger of every pull request, release signer, and security-disclosure
+first responder. There is no second maintainer, no steering
+committee, no technical advisory board, no rotating release captain.
+
+This matches the reality reflected elsewhere in the repo:
+
+- [`.github/CODEOWNERS`](.github/CODEOWNERS) lists `@apet97` as the
+  sole owner for every directory.
+- [`docs/production-readiness.md`](docs/production-readiness.md#governance)
+  labels this a single-maintainer project with self-merge permitted.
+- [`docs/branch-protection.md`](docs/branch-protection.md) documents
+  why the "Restrict who can push to matching branches" rule is
+  disabled (one user; no security benefit from an allow-list of one).
+
+This document is the single source of truth for that decision; the
+alternatives cited above reference back here.
+
+Operators evaluating whether to depend on `go-clockify`:
+you can read this document, see who is on the hook, and decide
+whether the audit trail that does exist (signed commits, public CI
+logs, SLSA build provenance where available, the release-smoke
+workflow) is sufficient for your risk appetite.
 
 ## Who can merge to `main`
 
-`@apet97` and `@backup-maintainer` are the maintainers with merge access to `main`. Branch
+`@apet97` is the only maintainer with merge access to `main`. Branch
 protection on `main` (snapshot in
 [`docs/branch-protection.md`](docs/branch-protection.md)) enforces
-the merge gate via required CI checks; it **enforces** a
-one-approval review rule.
+the merge gate via required CI checks and a one-approval review
+rule. Self-approval is permitted — it has to be, because there is
+nobody else to approve.
 
-`.github/CODEOWNERS` requires their approval on PRs that touch the security-
-sensitive surfaces listed below.
+`.github/CODEOWNERS` lists `@apet97` as the owner of every path;
+this is a stylistic declaration today (one-of-one), kept because it
+gives a future co-maintainer a clean diff target: adding a second
+handle to the per-path entries is a one-line PR per path rather
+than a ground-up rewrite.
 
 ## Merge gate
 
 A PR may merge to `main` only if all of the following are true:
 
 1. CI is green. Specifically, every required check listed in
-   `docs/branch-protection.md` reports success.
-2. The PR has been reviewed. For a self-authored PR, this means the other maintainer has reviewed and approved. For PRs from external contributors, this means at least one maintainer has reviewed and approved.
-3. The branch is up-to-date with `main` (linear history is preferred;
-   merge commits are accepted only if rebasing would lose context
-   from a long-lived feature branch).
-4. Commits are signed (or, where signing is not yet enforced by
-   branch protection, the maintainer has visually confirmed the
-   author).
-5. The change does not lower a coverage floor without an explicit
+   [`docs/branch-protection.md`](docs/branch-protection.md) reports
+   success.
+2. The branch is up-to-date with `main` (linear history is required;
+   see branch-protection.md).
+3. Commits are signed (required-signatures enforcement is on).
+4. The change does not lower a coverage floor without an explicit
    note in the PR body explaining why
-   (see `docs/coverage-policy.md`).
+   (see [`docs/coverage-policy.md`](docs/coverage-policy.md)).
+5. The PR has at least one approval. For a self-authored PR, this
+   means the maintainer reviewing against the checklist below
+   and self-approving. No-op at one-maintainer scale, but the
+   branch-protection rule stays because the audit trail of an
+   explicit approval click is meaningful.
 
 The merge gate is the same for self-authored PRs and external PRs.
-Self-merge is permitted after review, and the audit trail (signed
-commits, SLSA build provenance on every release, public CI logs)
-makes the chain reviewable after the fact.
+The audit trail (signed commits, SLSA build provenance on every
+release, public CI logs, release-smoke nightly verification) makes
+the chain reviewable after the fact.
 
-## Tighter expectations on security-sensitive areas
+## Tighter self-review expectations on security-sensitive areas
 
-For changes that touch any of the following directories, the
-maintainers commit to **dual review**:
+Until a second maintainer joins, "dual review" on sensitive areas
+is an aspiration rather than a mechanism. Today the expectation is
+**self-review against the sensitive-area checklist**: the PR body
+explicitly calls out which sensitive path is touched and how the
+change was validated. The sensitive paths that trigger this
+expectation are:
 
-- `internal/authn/`
-- `internal/enforcement/`
-- `internal/policy/`
-- `internal/transport/`
-- `internal/clockify/`
-- `.github/workflows/release.yml`
-- `.github/workflows/docker-image.yml`
-- `.goreleaser.yaml`
-- `deploy/`
+- `internal/authn/` — authentication and JWT verification.
+- `internal/enforcement/` — policy enforcement matrix.
+- `internal/policy/` — policy definitions.
+- `internal/transport/` — transport adapters (gRPC, streamable HTTP).
+- `internal/clockify/` — HTTP client and auth headers.
+- `.github/workflows/release.yml` — the release pipeline.
+- `.github/workflows/docker-image.yml` — the image pipeline.
+- `.goreleaser.yaml` — the release orchestrator.
+- `deploy/` — operator-facing deploy manifests.
+
+When a second maintainer joins, the sensitive-path list in
+`.github/CODEOWNERS` will switch on two required approvals via a
+CODEOWNERS entry change; until then, sensitive-path PRs are
+self-reviewed against this list and the rationale is documented in
+the PR body via the checkbox in
+`.github/PULL_REQUEST_TEMPLATE.md`.
 
 ## Releases
 
@@ -81,19 +115,26 @@ disclosure policy lives in [`SECURITY.md`](SECURITY.md), including
 the response timeline (acknowledgment within 48 hours, fix within
 1–2 weeks for high-severity).
 
-There is no separate security team. The maintainers are the security
+There is no separate security team. The maintainer is the security
 team. If `@apet97` is unreachable for an extended period, escalate
 via a public GitHub issue tagged `unreachable-maintainer`.
 
 ## Becoming a maintainer
 
-If you have been substantially contributing for several
-months and want to take on review responsibility, open a discussion
-or issue and the conversation will start.
+If you have been substantially contributing for several months and
+want to take on review responsibility, open a discussion or issue
+and the conversation will start. A second maintainer is an explicit
+goal (tracked in Wave L's second-maintainer-onboarding issue); this
+document gets a mechanical rewrite to "two-maintainer" on that
+event.
 
 ## Changes to this document
 
-Changes to this document follow the normal merge gate. Operators who
-depend on `go-clockify` and want to be notified of governance
+Changes to this document follow the normal merge gate. Operators
+who depend on `go-clockify` and want to be notified of governance
 changes should watch the repository for releases and read each
-release's CHANGELOG entry.
+release's CHANGELOG entry. The rationale for each change lives in
+`docs/adr/` so future readers can trace why the policy is what it
+is — see
+[ADR-0016](docs/adr/0016-single-maintainer-governance.md) for the
+single-maintainer decision.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,123 @@
+# Support
+
+`go-clockify` is a single-maintainer project today
+(see [GOVERNANCE.md](GOVERNANCE.md)). This document covers how to
+ask questions, what to expect when you do, and how to avoid
+surprises when taking a dependency on this project.
+
+## Where to ask
+
+| Kind of question | Where |
+|------------------|-------|
+| Bug report or feature request | [GitHub Issues](https://github.com/apet97/go-clockify/issues) |
+| Question about usage, configuration, or operations | [GitHub Issues](https://github.com/apet97/go-clockify/issues) with the `question` label |
+| Private security vulnerability | [GitHub Security Advisory](https://github.com/apet97/go-clockify/security/advisories/new) — see [SECURITY.md](SECURITY.md) for full disclosure policy |
+| "Is this change safe for my environment?" | Open an issue; pre-upgrade questions are explicitly welcome |
+
+GitHub Discussions is not enabled today. If the signal-to-noise
+ratio on issues becomes a problem, enabling it is one of the
+Wave L follow-ups.
+
+## Response expectations
+
+There is no SLA. A single maintainer working on a best-effort
+basis means questions and bugs land in the same backlog as
+feature work.
+
+Rough expectations, based on the last six months of activity:
+
+- Security disclosures acknowledged within 48 hours. Fix targeted
+  within 1–2 weeks for high-severity issues. This is the only
+  commitment in this document — security response is held to a
+  published timeline in [SECURITY.md](SECURITY.md).
+- Questions on routine usage: usually a same-day reply, sometimes
+  a few days.
+- Bugs that affect correctness on the stable `v1.x` wire format:
+  prioritised above feature work, targeted in the next point
+  release.
+- Bugs that affect secondary surfaces (legacy HTTP transport,
+  `-tags=fips`, `-tags=otel`): fixed as time allows.
+- Feature requests: triaged into the backlog; decisions on
+  whether to accept are posted on the issue.
+
+If a maintainer response is time-critical (incident triage,
+security disclosure follow-up), escalate by pinging the issue.
+GitHub notifications are actually read.
+
+## Commercial support
+
+None today. There is no commercial entity behind `go-clockify` —
+it is a personal open-source project released under the MIT
+license. Operators who need dedicated support are welcome to
+contract the maintainer directly, but no such arrangement exists
+as a standing offer.
+
+## Stability guarantees
+
+`go-clockify` follows [Semantic Versioning](https://semver.org/).
+`v1.0.0` shipped on 2026-04-12 and declared the wire format
+stable.
+
+What we promise for the `v1.x` series:
+
+- **Wire format stability.** MCP method names, tool names, and
+  env-var surface stay backward-compatible within `v1.x`. Any
+  change that would break a wire-compatible client bumps the
+  major.
+- **Env-var renames are breaking.** Env-var renames (not just
+  additions) only land in a major bump; today we use
+  `Deprecated: true` spec entries as a soft migration window
+  where we intentionally accept both.
+- **Signed releases.** Every tagged release ships with cosign
+  signatures, SBOM, and (where available) SLSA build provenance.
+  Verification recipe in [`docs/verification.md`](docs/verification.md).
+- **No surprise removals.** Deprecations are announced one minor
+  version before removal. The `MCP_HTTP_MAX_BODY` alias is the
+  canonical example: it will disappear no earlier than a
+  `v2` bump, and only if we also make other breaking changes
+  worth a major.
+
+What we do NOT promise:
+
+- A specific minor-release cadence. Minors ship when changes
+  warrant.
+- Long-term support for every minor. The latest minor is the
+  supported minor.
+- Backports of fixes to older minors. If you are on `v1.0.3` and
+  need the `v1.1.2` fix, upgrade to `v1.1.2`.
+
+## Upgrading
+
+Before upgrading, read the `CHANGELOG.md` Unreleased section and
+the target release's entry. Default changes (like Wave H's prod
+fail-closed defaults or Wave I's profile-based config) are called
+out in the Changed / Added sections. `clockify-mcp doctor` will
+tell you which of your env vars come from profile defaults vs.
+explicit operator intent — run it before and after an upgrade.
+
+## Version support matrix
+
+| Version | Status | Notes |
+|---------|--------|-------|
+| `v1.1.x` (Unreleased) | Active — where new features land | |
+| `v1.0.x` | Released 2026-04-12 through 2026-04-20; latest is `v1.0.3` | Patch fixes land here only for correctness regressions that affect the stable wire format |
+| `v0.x` | Pre-release; not supported | Pre-`v1` releases from March–April 2026; do not deploy |
+
+## Discussion etiquette
+
+- Include the output of `clockify-mcp doctor` (or your effective
+  env) when reporting a bug. It is the single fastest way to
+  reproduce what you are seeing.
+- If you are asking about operator decisions ("should I use
+  `shared-service` or `prod-postgres`?"), skim
+  [`docs/deploy/`](docs/deploy/) first — the profile docs answer
+  most common questions inline.
+- Minimal reproductions are load-bearing. "It broke" is hard to
+  action; "I ran `X`, expected `Y`, saw `Z`" is easy to action.
+
+## Thank you
+
+Issues with attached reproduction steps, PRs with tests, and
+reviewers who push back on unclear rationale — these are the
+things that make an open-source project sustainable for one
+maintainer. If you are doing any of those things, thank you.

--- a/docs/adr/0016-single-maintainer-governance.md
+++ b/docs/adr/0016-single-maintainer-governance.md
@@ -1,0 +1,155 @@
+# 0016 - Single-maintainer governance reality
+
+## Status
+
+Accepted — implemented on `wave-j/governance-source-of-truth`:
+
+1. `docs(governance): single source of truth — align maintainer docs`
+
+## Context
+
+Before Wave J, four operator-facing docs described the maintainer
+population inconsistently:
+
+| Doc | Claim |
+|-----|-------|
+| `GOVERNANCE.md:9-15` | "two-maintainer project today" + `@backup-maintainer` |
+| `.github/CODEOWNERS:15` | `* @apet97 @backup-maintainer` and per-path entries |
+| `docs/production-readiness.md:203` | "Single-maintainer project today (`@apet97`)" |
+| `docs/branch-protection.md:42` | "this is a single-maintainer repository (see GOVERNANCE.md)" — but GOVERNANCE.md said otherwise |
+
+`@backup-maintainer` was a placeholder handle from an earlier draft,
+not a real GitHub user. Merging a PR through CODEOWNERS would
+therefore fall back to the `*` rule regardless of what the per-path
+entries said — the whole scaffolding resolved to `@apet97`, with the
+`@backup-maintainer` text serving as documentation aspiration rather
+than enforcement.
+
+The contradiction was noticed during a governance audit on
+2026-04-22. Operators reading GOVERNANCE.md were getting a different
+story than operators reading production-readiness.md, and the
+mismatch was visible from the first line of either doc. An external
+reviewer would reasonably conclude one of three things:
+
+1. Docs are stale — which means other operator-facing docs might be
+   too.
+2. The project actually has a hidden second maintainer — which
+   means the audit trail is thinner than advertised.
+3. The project is single-maintainer with aspirational docs — which
+   is fine, but should be labelled honestly.
+
+Reality is #3. Wave J makes #3 the written truth.
+
+## Decision
+
+Align all governance-relevant docs on "single-maintainer project
+today":
+
+- `GOVERNANCE.md` is rewritten to open with "single-maintainer
+  project today," soften the dual-review section to "tighter
+  self-review expectations," and point at ADR 0016 for the
+  rationale. Self-merge is explicitly permitted (already the
+  reality, now documented).
+- `.github/CODEOWNERS` drops `@backup-maintainer` from every entry.
+  The per-path entries stay — a future co-maintainer addition is a
+  one-line PR per path, which is a clean diff target.
+- `SUPPORT.md` is added at repo root (new file) with the "single
+  maintainer, best-effort, no SLA" expectation, the security
+  timeline pointer, and the `v1.x` stability guarantee.
+- `.github/PULL_REQUEST_TEMPLATE.md` gets a sensitive-area
+  checkbox so PRs touching security-sensitive paths document the
+  self-review against the checklist in GOVERNANCE.md.
+- `docs/production-readiness.md` is unchanged — it was already
+  consistent with the new target.
+- `docs/branch-protection.md` is unchanged — it already
+  documented single-maintainer reality in its footnotes.
+
+Dual-review on sensitive areas becomes an aspiration for when a
+second maintainer joins (tracked in Wave L's
+"second-maintainer-onboarding" issue). Until then, sensitive-area
+PRs get an explicit self-review callout in the PR body, with the
+checklist items that apply documented there.
+
+## Consequences
+
+### Positive
+
+- One consistent story across every governance-relevant doc.
+  Operators land on a clear trust statement regardless of which
+  doc they open first.
+- Removing `@backup-maintainer` stops the CODEOWNERS UI from
+  silently falling back to `*`. The per-path entries now truthfully
+  describe the owner.
+- `SUPPORT.md` fills a visible gap — operators evaluating
+  dependency risk had to piece together SLA expectations from
+  SECURITY.md + README + GOVERNANCE.md. Now one page.
+- The sensitive-area checkbox in the PR template turns "tighter
+  self-review" from a vibes-based commitment into a visible,
+  document-in-the-PR-body commitment.
+
+### Negative
+
+- Dual review is explicitly aspirational rather than a mechanism.
+  This is the honest state, but some operators prefer a written
+  commitment even when it is one-of-one today.
+- A future co-maintainer event requires synchronised edits to
+  GOVERNANCE.md, CODEOWNERS, and (optionally) the PR template.
+  Mitigated by pointing every doc at this ADR so the checklist is
+  in one place.
+
+## Alternatives considered
+
+### A. Keep the two-maintainer fiction and hope nobody notices
+
+Rejected. Operators doing a dependency audit before taking a
+production dependency will notice, and the mismatch would suggest
+a broader hygiene problem.
+
+### B. Invent a real second maintainer
+
+Rejected. A maintainer is a real commitment; inflating the count
+by inventing one is worse than being honest about one.
+
+### C. Remove CODEOWNERS entirely
+
+Rejected. Removing CODEOWNERS loses the per-path review signal
+that GitHub surfaces on every PR. Keeping the scaffolding (with
+one handle per line) preserves that signal and gives a clean
+future-diff target.
+
+### D. Automate governance-doc parity via a CI gate
+
+Considered. A grep-based gate could check that every
+governance-relevant doc says "single-maintainer" consistently.
+Rejected for Wave J because the surface is small (four docs)
+and because doc-parity CI gates tend to be noisy. The doc
+structure (pointing everything back to GOVERNANCE.md and ADR
+0016) is lighter-weight enforcement. Revisit if we acquire the
+second maintainer or drift reappears.
+
+## Follow-ups
+
+Tracked in Wave L issues:
+
+- **Second-maintainer onboarding.** Once a candidate appears,
+  GOVERNANCE.md gets a mechanical "single-maintainer" →
+  "two-maintainer" edit, CODEOWNERS adds the handle to each
+  per-path entry, and the sensitive-area checkbox in the PR
+  template switches from self-review to dual-review.
+- **Branch-protection hardening once a second maintainer joins.**
+  Flip `enforce_admins` on, consider pushing required approvals
+  from 1 to 2 for sensitive paths via CODEOWNERS enforcement.
+- **Auto-generate branch-protection.md.** Currently blocked by
+  the GitHub API returning 403 on user-owned private repos; the
+  auto-gen gate becomes viable once the repo flips to public or
+  to an org.
+
+## References
+
+- `GOVERNANCE.md` — the maintainer-count and merge-gate rules.
+- `.github/CODEOWNERS` — per-path ownership.
+- `SUPPORT.md` — adoption-time expectations.
+- `docs/production-readiness.md` — already consistent with the
+  new GOVERNANCE.md.
+- `docs/branch-protection.md` — already consistent with the new
+  GOVERNANCE.md; references this ADR in the footnotes.


### PR DESCRIPTION
## Summary

Wave J — reconciles `GOVERNANCE.md`, `.github/CODEOWNERS`, and the PR template on the single-maintainer reality already reflected in `docs/production-readiness.md` and `docs/branch-protection.md`. Drops the `@backup-maintainer` placeholder that never resolved to a real GitHub handle. Adds `SUPPORT.md` (new) and ADR-0016 (new) codifying the decision.

One atomic commit: `docs(governance): single source of truth — align maintainer docs`.

### What was misaligned

| Doc | Before | After |
|-----|--------|-------|
| GOVERNANCE.md | "two-maintainer project today" + `@backup-maintainer` | "single-maintainer project today" + self-merge rules |
| .github/CODEOWNERS | Every path listed `@apet97 @backup-maintainer` | Every path lists `@apet97`; per-path entries kept for future diff target |
| .github/PULL_REQUEST_TEMPLATE.md | Only a build/test checklist | + GOVERNANCE pointer + sensitive-area checkbox |
| SUPPORT.md | did not exist | new — SLA expectations, v1.x stability, security pointer |
| docs/adr/0016-single-maintainer-governance.md | did not exist | new — locks the decision + four rejected alternatives |

### Scoped out

- **Auto-generate `docs/branch-protection.md` via CI.** The GitHub API returns 403 on user-owned private repos for the `/branches/{branch}/protection` endpoint, so the gate cannot run. Tracked as a Wave L follow-up issue pending a repo flip to an org or public account.

## Test plan

- [x] `grep -n 'single-maintainer' GOVERNANCE.md docs/production-readiness.md .github/CODEOWNERS docs/branch-protection.md` — every doc tells the same story.
- [x] `grep -n '@backup-maintainer' .github/CODEOWNERS` — no matches.
- [x] `scripts/check-doc-parity.sh` — doc-parity: OK (no dangling markers).
- [x] `make release-check` — `release-check: OK — shippable` locally.
- [ ] CI: Lint, Format, Test, Coverage, Vet, Vulncheck, Build, Test (HTTP smoke), Config doc parity, Deploy render, Fuzz, Repo hygiene, Secret scan, Build+scan+sign.

Related: Closes the governance inconsistency called out in the ULTRATHINK backlog Wave J. Does not change any code paths.