### PR TITLE
chore(ci): pin toolchain + govulncheck SHA + add build matrix

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -1,0 +1,63 @@
+name: Build matrix
+
+# Compile-only build-tag matrix. Complements the main CI "Build" job
+# (which covers the default build) by asserting every tag combination
+# we ship compiles cleanly on its own. Tests are NOT run here — the
+# goal is a fast supply-chain signal that tagged builds don't rot
+# silently when the default path gets refactored. Per-tag test
+# coverage lives in the main CI matrix and in scripts/check-build-tags.sh
+# (which is also run under `make release-check` locally).
+#
+# Why compile-only: the matrix adds six jobs to every PR and every
+# push to main. Running full test suites per cell would triple CI
+# minutes. Compile-only pays for itself when a refactor to the default
+# path accidentally breaks a gated sub-module — which has happened
+# twice in wave history, both caught after the fact.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Wednesday 04:00 UTC. Picks up govulncheck-style
+    # drift when an upstream dependency under a build tag
+    # publishes something incompatible with the pinned go
+    # version.
+    - cron: "0 4 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    name: Build -tags=${{ matrix.tags }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tags:
+          - "grpc"
+          - "fips"
+          - "otel"
+          - "pprof"
+          - "grpc,otel"
+          - "fips,grpc"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25.9"
+      - name: Compile
+        env:
+          TAGS: ${{ matrix.tags }}
+        run: |
+          set -euo pipefail
+          # GOFIPS140 is only honoured under -tags=fips; setting it
+          # unconditionally is harmless — Go ignores it when fips is
+          # not active.
+          if [[ "${TAGS}" == *"fips"* ]]; then
+            export GOFIPS140=latest
+          fi
+          echo "Compiling with -tags=${TAGS} (GOFIPS140=${GOFIPS140:-unset})"
+          go build -tags="${TAGS}" ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,17 @@ jobs:
         with:
           go-version: "1.25.9"
       - name: Run govulncheck
-        # Install from master so the binary's bundled go/types supports the
-        # module's current Go directive (go1.25). The last tagged release
-        # (v1.1.4) was built with go1.24 and refuses to parse go1.25 code.
+        # Pin to a specific golang.org/x/vuln commit so supply-chain
+        # auditors can point at what actually ran. The last tagged
+        # release (v1.1.4) was built with go1.24 and refuses to
+        # parse go1.25 code; pinning @master is too volatile for a
+        # production CI gate. Revisit once a tagged release supports
+        # go1.25 — tracked as a Wave L follow-up issue.
+        #
+        # SHA resolved 2026-04-22 against
+        # https://github.com/golang/vuln/commits/master.
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@master
+          go install golang.org/x/vuln/cmd/govulncheck@5499630db5f896778f084a8b3720910426de5c53
           govulncheck ./...
 
   build:

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/apet97/go-clockify
 
 go 1.25.9
 
-toolchain go1.25.9
-
 replace github.com/apet97/go-clockify/internal/tracing/otel => ./internal/tracing/otel
 
 require github.com/apet97/go-clockify/internal/tracing/otel v0.0.0-00010101000000-000000000000

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/apet97/go-clockify
 
 go 1.25.9
 
+toolchain go1.25.9
+
 replace github.com/apet97/go-clockify/internal/tracing/otel => ./internal/tracing/otel
 
 require github.com/apet97/go-clockify/internal/tracing/otel v0.0.0-00010101000000-000000000000

--- a/scripts/check-build-tags.sh
+++ b/scripts/check-build-tags.sh
@@ -102,6 +102,13 @@ if [ -z "${FIPS_ONLY:-}" ]; then
     echo "== -tags=pprof,otel =="
     go build -tags=pprof,otel ./...
 
+    echo "== -tags=grpc,otel =="
+    # Combinatorial: gRPC transport plus OTel exporters. Verifies the
+    # otel interceptor path compiles when both tags are active — this
+    # matters because the OTel wiring is a thin adapter over a stdlib
+    # fallback, and the adapter only shows up under -tags=otel.
+    go build -tags=grpc,otel ./...
+
     echo "== -tags=postgres =="
     go build -tags=postgres ./...
     (cd internal/controlplane/postgres && go build -tags=postgres ./... && go vet -tags=postgres ./...)
@@ -125,3 +132,10 @@ if ! echo "$output" | grep -q "fips140_enabled"; then
     exit 1
 fi
 go test -tags=fips -count=1 -timeout 120s ./...
+
+echo "== -tags=fips,grpc (GOFIPS140=latest) =="
+# Combinatorial: FIPS + gRPC. Verifies that the gRPC transport
+# builds cleanly under GOFIPS140 — a real risk path because the
+# gRPC dependency chain transitively pulls in crypto choices
+# that need the FIPS-capable primitives.
+go build -tags=fips,grpc ./...


### PR DESCRIPTION
## Summary

Wave K — three related CI/toolchain tightenings:

1. **`go.mod toolchain go1.25.9` directive.** Older local Go installs auto-download 1.25.9 instead of erroring on the `go 1.25.9` line.
2. **`govulncheck` pinned to commit `5499630d`.** Replaces `@master` with a reproducible SHA so supply-chain auditors can reconstruct what actually ran. Revisit once a tagged release supports go1.25 — tracked as a Wave L issue.
3. **`.github/workflows/build-matrix.yml`** runs compile-only checks on six tag combos every push / PR / weekly cron: `grpc`, `fips`, `otel`, `pprof`, `grpc,otel`, `fips,grpc`. Pairs with an extended `scripts/check-build-tags.sh` so `make release-check` exercises the same combos locally.

One atomic commit.

## Test plan

- [x] `go build ./...` on the default toolchain — clean (go.mod change is additive).
- [x] `bash scripts/check-build-tags.sh` — all ten sections pass locally (default, go.mod parity, otel, grpc, pprof, pprof+otel, grpc+otel, postgres, fips, fips+grpc).
- [x] `make release-check` — `release-check: OK — shippable`.
- [ ] CI — existing jobs stay green; the new Build-matrix workflow runs all six cells in parallel.