### PR TITLE
chore(ci): remove SLSA private-repo workarounds; repo is public now

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -243,15 +243,11 @@ jobs:
             "$IMAGE_REF"
 
       - name: Attest SLSA build provenance
-        # Attestation is unavailable for user-owned private
-        # repositories — GitHub's feature gate. Make this step
-        # non-fatal so the main-branch build pipeline stays green;
-        # when the repo is flipped to public (or moved under an
-        # org), attestations activate automatically. The release
-        # workflow (tag-triggered) still attests binaries; this
-        # step covers the main-branch container image build.
+        # Repo is public (2026-04-22) — attestation is mandatory
+        # on every published image now. The release workflow
+        # (tag-triggered) attests binaries; this step covers the
+        # main-branch container image build.
         if: github.event_name != 'pull_request'
-        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -158,33 +158,18 @@ jobs:
           # service. --owner pins the trust root to this org so a
           # malicious lookalike binary fails closed.
           #
-          # On user-owned private repositories the attestation
-          # service returns "Feature not available for user-owned
-          # private repositories" (HTTP 404). release.yml's
-          # attest-build-provenance step is continue-on-error for
-          # the same reason (commit 6f4f748), so on that account
-          # tier no attestation is actually produced and verifying
-          # a missing attestation cannot succeed.
+          # Repo is public (2026-04-22) — the earlier "feature not
+          # available for user-owned private repos" skip branch is
+          # removed. Any attestation-verify failure is now a hard
+          # smoke failure (signature mismatch, missing bundle,
+          # wrong owner, expired root, or unreleased-tag attestation
+          # propagation delay).
           #
-          # We treat the narrow "feature not available" / HTTP 404
-          # outcome as SKIPPED (::notice::); the two mandatory
-          # cosign checks below still gate the smoke. Every other
-          # failure mode (signature mismatch, missing bundle,
-          # wrong owner, expired root) stays fatal. See
-          # docs/adr/0013-private-repo-slsa-posture.md for rationale.
-          log=$(mktemp)
-          if gh attestation verify artifacts/clockify-mcp-linux-x64 \
-              --owner "${GITHUB_REPOSITORY_OWNER}" >"$log" 2>&1; then
-            cat "$log"
-            exit 0
-          fi
-          cat "$log"
-          if grep -qE 'Feature not available for user-owned private repositor|HTTP 404' "$log"; then
-            echo "::notice title=SLSA attestation skipped::GitHub attestation service is unavailable for user-owned private repositories. cosign blob + image checks remain mandatory. See docs/adr/0013-private-repo-slsa-posture.md."
-            exit 0
-          fi
-          echo "::error::gh attestation verify failed with a non-skippable error. See log above."
-          exit 1
+          # ADR-0013 captures the historical context of why the
+          # skip existed; it is kept as a record of the private-repo
+          # period and not as a live escape hatch.
+          gh attestation verify artifacts/clockify-mcp-linux-x64 \
+            --owner "${GITHUB_REPOSITORY_OWNER}"
 
       - name: Verify cosign keyless signature on binary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,10 @@ jobs:
           cp dist/clockify-mcp_linux_arm64_v8.0/clockify-mcp   staging/clockify-mcp-linux-arm64
           cp dist/clockify-mcp_windows_amd64_v1/clockify-mcp.exe staging/clockify-mcp-windows-x64.exe
       - name: Generate SLSA build provenance attestation
-        # Attestation is unavailable for user-owned private repos —
-        # GitHub's feature gate. continue-on-error keeps the rest of
-        # the release pipeline (npm publish, reproducibility trigger)
-        # running. When the repo flips to public (or moves under an
-        # org), attestations activate automatically.
-        continue-on-error: true
+        # Repo is public (2026-04-22) — attestation is now a
+        # mandatory gate on release. A failure here must fail the
+        # release rather than silently drop the SLSA row from the
+        # supply-chain chain.
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **SLSA attestation is now mandatory on release.** The repo
+  flipped to public on 2026-04-22, which unblocked the GitHub
+  attestation service for this account tier.
+  `actions/attest-build-provenance` in `release.yml` and
+  `docker-image.yml` is no longer `continue-on-error: true`; the
+  `gh attestation verify` step in `release-smoke.yml` no longer
+  treats HTTP 404 as a skip. A missing or invalid attestation
+  will now fail the release or the smoke. ADR-0013 is marked
+  superseded; the workaround it documented is no longer live.
+
 ### Added
 
 - **Canonical deployment profiles (`--profile=<name>`).** Five

--- a/docs/adr/0013-private-repo-slsa-posture.md
+++ b/docs/adr/0013-private-repo-slsa-posture.md
@@ -2,9 +2,21 @@
 
 ## Status
 
-Accepted — codifies the release-smoke skip path added alongside
-this ADR and the `continue-on-error` treatment already in
-`release.yml` and `docker-image.yml`.
+**Superseded 2026-04-22 — the repository flipped to public.** The
+skip path and `continue-on-error` treatments this ADR codified
+are removed; SLSA attestation is now a mandatory gate on every
+release and every main-branch image push. The ADR stays in the
+tree as the historical record of why the private-repo workaround
+existed from 2026-04-22 (SLSA workaround introduction via Wave G)
+through 2026-04-22 (this flip) — roughly the v1.0.0–v1.0.3 era.
+Future readers finding a reference to this ADR in a commit
+message or PR body should understand: private-repo posture, no
+longer live.
+
+Prior status (pre-supersedure): Accepted — codifies the
+release-smoke skip path added alongside this ADR and the
+`continue-on-error` treatment already in `release.yml` and
+`docker-image.yml`.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Repo flipped to public 2026-04-22. The SLSA-skip workarounds installed in Wave G (PR #16) are now dead weight — worse, they would silently mask a real signing-pipeline break. Removes them across three workflows and supersedes ADR-0013.

- `release.yml` — `actions/attest-build-provenance` is no longer `continue-on-error: true`.
- `docker-image.yml` — same, for the main-branch image push path.
- `release-smoke.yml` — the HTTP-404 / "feature not available" skip branch is deleted; the step is now a straight `gh attestation verify` with no fallback.
- `docs/adr/0013-private-repo-slsa-posture.md` — marked **Superseded 2026-04-22**; prior text kept as historical record of the private-repo workaround era (v1.0.0–v1.0.3).
- `CHANGELOG.md` — Unreleased entry documents the shift from optional to mandatory SLSA attestation.

Closes the SLSA sub-goal of Wave L issue #24 (the auto-generate branch-protection follow-up is a separate item).

## Test plan

- [x] `make release-check` — `release-check: OK — shippable`.
- [x] `gh repo view apet97/go-clockify --json visibility` → `"public"`.
- [x] Manual re-read of each workflow: no conditional fallback remains on the three attestation steps; each step now fails closed.
- [ ] CI.
- [ ] Post-merge: dispatch `gh workflow run release-smoke.yml -f tag=v1.0.3` and confirm the SLSA step passes (attestation should exist post-flip for tags that were built while private, with some service propagation lag possible — if it fails, that's informative).