### PR TITLE
chore(docs): drop production-grade / best-in-class puffery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clockify-mcp-go
 
-> A production-grade [Model Context Protocol][mcp] server for [Clockify][clockify] — plug any MCP client into your time-tracking workspace and let it log time, run reports, and manage projects on your behalf.
+> A [Model Context Protocol][mcp] server for [Clockify][clockify] — plug any MCP client into your time-tracking workspace and let it log time, run reports, and manage projects on your behalf.
 
 [![Go version](https://img.shields.io/badge/go-1.25-00ADD8?logo=go)](go.mod)
 [![Release](https://img.shields.io/github/v/release/apet97/go-clockify?color=7e57c2)](https://github.com/apet97/go-clockify/releases)

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -7,7 +7,7 @@ This document provides guidance on how various Model Context Protocol (MCP) clie
 | Client | Connection Mode | Stability | Notes |
 |--------|-----------------|-----------|-------|
 | Claude Code | `stdio` | Tier 1 | Full support for all tools and resources. |
-| Claude Desktop | `stdio` | Tier 1 | Best-in-class support for tool rendering. |
+| Claude Desktop | `stdio` | Tier 1 | Renders tool confirmation dialogs for `destructiveHint: true` tools. |
 | Cursor | `stdio` | Tier 1 | Supports via `.cursor/mcp.json`. |
 | Codex | `stdio` | Tier 1 | Lightweight CLI. |
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -47,8 +47,10 @@ Legend:
   you understand the tradeoff.
 - **❌ Unsupported** — Either blocked at startup (e.g. `memory`
   backend with `ENVIRONMENT=prod`) or actively discouraged
-  because the security/operational posture cannot be made
-  production-grade without a different combination.
+  because the security/operational posture of the combination
+  fails at least one of: fail-closed audit, authenticated
+  transport, multi-process-safe control plane, or deny-default
+  legacy HTTP.
 
 Every "Recommended" row has a corresponding file under
 `docs/deploy/`:

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -192,6 +192,6 @@ the open issue is the exclusive failure signal.
 - [`docs/runbooks/image-digest-pinning.md`](runbooks/image-digest-pinning.md)
   — deploy-time digest pinning policy for the prod overlay.
 - [`docs/release/deploy-readiness-checklist.md`](release/deploy-readiness-checklist.md)
-  — mandatory manual checklist for production-ready deployments.
+  — manual checklist to run before promoting a release.
 - [`docs/support-matrix.md`](support-matrix.md)
   — supported Go versions, OS/architectures, and upstream Clockify API compatibility.


### PR DESCRIPTION
## Summary

Removes four tokens of adoption-marketing adjectives from shipped docs. The underlying claims (signed releases, fail-closed posture, policy modes, multi-process control plane) are still made, just in specific terms rather than catch-all adjectives.

| Location | Before | After |
|---|---|---|
| `README.md:3` | "A production-grade Model Context Protocol server..." | "A Model Context Protocol server..." |
| `docs/clients.md:10` | "Best-in-class support for tool rendering." | "Renders tool confirmation dialogs for `destructiveHint: true` tools." |
| `docs/support-matrix.md:51` | "cannot be made production-grade without a different combination" | the four specific checks the Unsupported tier fails |
| `docs/verification.md:195` | "mandatory manual checklist for production-ready deployments" | "manual checklist to run before promoting a release" |

Repo metadata (out-of-tree): GitHub description changed from "Production-grade Model Context Protocol server..." to "Model Context Protocol server for Clockify. 124 tools, three transports (stdio / streamable HTTP / optional gRPC), four policy modes, cosign-signed releases."

## Test plan

- [x] `grep -rE 'production-grade|production-ready|prod-ready|best-in-class|enterprise-grade' docs/ README.md` → no matches.
- [x] `make release-check` green.
- [ ] CI (Lychee will re-verify all links since .md files changed).