### PR TITLE
fix: stabilize benchmark loop and add Claude automation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -147,6 +147,12 @@ jobs:
           # postgres://...). Metrics are exposed on a dedicated listener
           # because /metrics is not mounted on the streamable_http main
           # listener.
+          # MCP_ALLOW_ANY_ORIGIN=1 satisfies the startup preflight added
+          # in config(load): the Dockerfile ships MCP_STRICT_HOST_CHECK=1
+          # with a non-loopback bind (0.0.0.0:8080); config.Load() rejects
+          # that combination unless an allowlist or allow-any flag is set.
+          # Origin enforcement itself is covered by unit tests; the smoke
+          # test only needs the server to start and serve HTTP.
           cid="$(docker run -d --rm \
             -p 127.0.0.1:8091:8080 \
             -p 127.0.0.1:8092:8082 \
@@ -157,6 +163,7 @@ jobs:
             -e MCP_ALLOW_DEV_BACKEND=1 \
             -e MCP_METRICS_BIND=:8082 \
             -e MCP_METRICS_BEARER_TOKEN=smoke-test-metrics-token-1234567890 \
+            -e MCP_ALLOW_ANY_ORIGIN=1 \
             "$IMAGE_REF")"
           cleanup() {
             docker rm -f "$cid" >/dev/null 2>&1 || true

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ desktop.ini
 CLAUDE.md
 AGENTS.md
 .claude-loop/
+
+*.test
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ desktop.ini
 # part of the shipped project.
 CLAUDE.md
 AGENTS.md
+.claude-loop/

--- a/STABILIZATION_LOOP.md
+++ b/STABILIZATION_LOOP.md
@@ -1,0 +1,9 @@
+# Stabilization Loop State
+
+Rules:
+- One Claude pass = one issue = one commit.
+- Stabilize before optimizing.
+- Do not weaken auth, audit, policy, dry-run, rate limits, validation, or MCP protocol behavior.
+- Preserve stdlib-only default build.
+- Use generators for generated docs.
+- Keep changes narrow.

--- a/internal/enforcement/enforcement_bench_test.go
+++ b/internal/enforcement/enforcement_bench_test.go
@@ -2,6 +2,7 @@ package enforcement
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/apet97/go-clockify/internal/authn"
@@ -17,8 +18,8 @@ import (
 // production tools/call traverses when an OIDC principal is on the
 // context.
 func BenchmarkPipelineBeforeCall(b *testing.B) {
-	rl := ratelimit.New(10000, 1000000, 60000)
-	rl.SetPerTokenLimits(1000, 100000)
+	rl := ratelimit.New(10000, math.MaxInt64, 60000)
+	rl.SetPerTokenLimits(1000, math.MaxInt64)
 	p := &Pipeline{
 		Policy:    standardPolicy(),
 		RateLimit: rl,
@@ -46,7 +47,7 @@ func BenchmarkPipelineBeforeCall(b *testing.B) {
 // This is the stdio transport's hot path when no authenticator is
 // installed.
 func BenchmarkPipelineBeforeCallNoPrincipal(b *testing.B) {
-	rl := ratelimit.New(10000, 1000000, 60000)
+	rl := ratelimit.New(10000, math.MaxInt64, 60000)
 	p := &Pipeline{
 		Policy:    standardPolicy(),
 		RateLimit: rl,

--- a/internal/ratelimit/ratelimit_bench_test.go
+++ b/internal/ratelimit/ratelimit_bench_test.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"math"
 	"testing"
 )
 
@@ -11,8 +12,8 @@ import (
 // concurrency semaphore + per-subject map lookup + per-subject window
 // check — the full happy path for an authenticated production call.
 func BenchmarkAcquireForSubjectSteady(b *testing.B) {
-	rl := New(10000, 1000000, 60000)
-	rl.SetPerTokenLimits(1000, 100000)
+	rl := New(10000, math.MaxInt64, 60000)
+	rl.SetPerTokenLimits(1000, math.MaxInt64)
 	const subject = "bench-subject"
 	ctx := context.Background()
 
@@ -33,7 +34,7 @@ func BenchmarkAcquireForSubjectSteady(b *testing.B) {
 // (empty subject → per-token sub-layer skipped). This is the floor
 // cost of the limiter and the baseline for measuring per-token overhead.
 func BenchmarkAcquireForSubjectNoPerToken(b *testing.B) {
-	rl := New(10000, 1000000, 60000)
+	rl := New(10000, math.MaxInt64, 60000)
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -54,7 +55,7 @@ func BenchmarkAcquireForSubjectNoPerToken(b *testing.B) {
 // BenchmarkAcquireForSubjectNoPerToken to attribute the subject-branch
 // overhead.
 func BenchmarkAcquireGlobal(b *testing.B) {
-	rl := New(10000, 1000000, 60000)
+	rl := New(10000, math.MaxInt64, 60000)
 	ctx := context.Background()
 
 	b.ReportAllocs()

--- a/internal/timeparse/timeparse.go
+++ b/internal/timeparse/timeparse.go
@@ -87,27 +87,33 @@ func ParseDatetime(s string, loc *time.Location) (time.Time, error) {
 		return t.UTC(), nil
 	}
 
-	// 8. RFC3339
+	// 8. date-only fast path: "2006-01-02" is the only supported format of
+	// length 10.  RFC3339 needs ≥20 chars; all datetime-with-time layouts
+	// need ≥16.  Jumping straight to the date parse avoids one RFC3339 and
+	// four layout parse attempts — each failure allocates a *time.ParseError.
+	if len(s) == 10 {
+		if t, err := time.ParseInLocation("2006-01-02", s, loc); err == nil {
+			return t.UTC(), nil
+		}
+		return time.Time{}, fmt.Errorf("unrecognized datetime format: %q", s)
+	}
+
+	// 9. RFC3339
 	if t, err := time.Parse(time.RFC3339, s); err == nil {
 		return t.UTC(), nil
 	}
 
-	// 9-12. datetime layouts without timezone
+	// 10-13. datetime layouts without timezone
 	layouts := []string{
-		"2006-01-02T15:04",    // 9
-		"2006-01-02 15:04",    // 10
-		"2006-01-02T15:04:05", // 11
-		"2006-01-02 15:04:05", // 12
+		"2006-01-02T15:04",    // 10
+		"2006-01-02 15:04",    // 11
+		"2006-01-02T15:04:05", // 12
+		"2006-01-02 15:04:05", // 13
 	}
 	for _, layout := range layouts {
 		if t, err := time.ParseInLocation(layout, s, loc); err == nil {
 			return t.UTC(), nil
 		}
-	}
-
-	// 13. date only
-	if t, err := time.ParseInLocation("2006-01-02", s, loc); err == nil {
-		return t.UTC(), nil
 	}
 
 	// 14. give up

--- a/run_claude_stabilize_loop.sh
+++ b/run_claude_stabilize_loop.sh
@@ -34,8 +34,36 @@ BRANCH="${BRANCH:-stabilize/quality-perf}"
 AUTO_PUSH="${AUTO_PUSH:-0}"
 CLAUDE_TIMEOUT_SECONDS="${CLAUDE_TIMEOUT_SECONDS:-1800}"
 LOG_DIR="${LOG_DIR:-.claude-loop}"
+RUN_FINAL_REVIEW="${RUN_FINAL_REVIEW:-0}"
+WATCH_CHECKS="${WATCH_CHECKS:-0}"
+PR_NUMBER="${PR_NUMBER:-}"
 
 mkdir -p "$LOG_DIR"
+
+watch_pr_checks() {
+  if [ "$WATCH_CHECKS" != "1" ]; then
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "== WATCH_CHECKS=1 but gh CLI is not installed; skipping check watch =="
+    return 0
+  fi
+
+  local pr="$PR_NUMBER"
+  if [ -z "$pr" ]; then
+    pr="$(gh pr view --json number -q .number 2>/dev/null || true)"
+  fi
+
+  if [ -z "$pr" ]; then
+    echo "== WATCH_CHECKS=1 but no PR number found; skipping check watch =="
+    return 0
+  fi
+
+  echo "== watching GitHub checks for PR #$pr =="
+  gh pr checks "$pr" --watch
+}
+
 
 # ---- Preflight --------------------------------------------------------------
 
@@ -337,6 +365,7 @@ EOF
   if [ "$AUTO_PUSH" = "1" ]; then
     echo "== AUTO_PUSH=1: pushing $BRANCH =="
     git push -u origin "$BRANCH"
+    watch_pr_checks
   else
     echo "== AUTO_PUSH=0: not pushing (set AUTO_PUSH=1 to enable) =="
   fi
@@ -345,6 +374,15 @@ EOF
 done
 
 # ---- Final review -----------------------------------------------------------
+
+if [ "$RUN_FINAL_REVIEW" != "1" ]; then
+  echo "== RUN_FINAL_REVIEW=0: skipping final release review =="
+  if [ "$AUTO_PUSH" = "1" ]; then
+    watch_pr_checks
+  fi
+  echo "== loop complete =="
+  exit 0
+fi
 
 echo
 echo "============================================================"
@@ -401,6 +439,7 @@ fi
 
 if [ "$AUTO_PUSH" = "1" ]; then
   git push -u origin "$BRANCH" || true
+  watch_pr_checks
 fi
 
 # ---- Summary ----------------------------------------------------------------

--- a/run_claude_stabilize_loop.sh
+++ b/run_claude_stabilize_loop.sh
@@ -22,6 +22,9 @@
 
 set -euo pipefail
 
+export GIT_PAGER=cat
+export PAGER=cat
+
 # ---- Config -----------------------------------------------------------------
 
 MAX_PASSES="${MAX_PASSES:-3}"
@@ -408,7 +411,7 @@ echo "== Loop finished                                             "
 echo "============================================================"
 echo "Branch:     $(git rev-parse --abbrev-ref HEAD)"
 echo "Recent commits:"
-git log --oneline -5
+git --no-pager log --oneline -5
 echo
 echo "Working tree status:"
 git status

--- a/run_claude_stabilize_loop.sh
+++ b/run_claude_stabilize_loop.sh
@@ -10,6 +10,7 @@
 #   MAX_PASSES=1 ./run_claude_stabilize_loop.sh
 #   MAX_PASSES=3 ./run_claude_stabilize_loop.sh
 #   MAX_PASSES=3 AUTO_PUSH=1 ./run_claude_stabilize_loop.sh
+#   MAX_PASSES=1 AUTO_PUSH=1 WATCH_CHECKS=1 PR_NUMBER=48 RUN_FINAL_REVIEW=0 ./run_claude_stabilize_loop.sh
 #
 # Env knobs (with defaults):
 #   MAX_PASSES=3
@@ -19,6 +20,9 @@
 #   AUTO_PUSH=0
 #   CLAUDE_TIMEOUT_SECONDS=1800
 #   LOG_DIR=.claude-loop
+#   RUN_FINAL_REVIEW=0
+#   WATCH_CHECKS=0
+#   PR_NUMBER=
 
 set -euo pipefail
 

--- a/run_claude_stabilize_loop.sh
+++ b/run_claude_stabilize_loop.sh
@@ -1,0 +1,417 @@
+#!/usr/bin/env bash
+# run_claude_stabilize_loop.sh
+#
+# Autonomous Claude Code loop for stabilizing and optimizing go-clockify.
+# One pass = one issue = one commit. Reviewer pass after each impl pass.
+# Stops on BLOCKER/REVERT verdicts or gate failures. Never destructive
+# to working tree, never force-resets, never skips git hooks.
+#
+# Usage:
+#   MAX_PASSES=1 ./run_claude_stabilize_loop.sh
+#   MAX_PASSES=3 ./run_claude_stabilize_loop.sh
+#   MAX_PASSES=3 AUTO_PUSH=1 ./run_claude_stabilize_loop.sh
+#
+# Env knobs (with defaults):
+#   MAX_PASSES=3
+#   MODEL_IMPL=sonnet
+#   MODEL_REVIEW=opus
+#   BRANCH=stabilize/quality-perf
+#   AUTO_PUSH=0
+#   CLAUDE_TIMEOUT_SECONDS=1800
+#   LOG_DIR=.claude-loop
+
+set -euo pipefail
+
+# ---- Config -----------------------------------------------------------------
+
+MAX_PASSES="${MAX_PASSES:-3}"
+MODEL_IMPL="${MODEL_IMPL:-sonnet}"
+MODEL_REVIEW="${MODEL_REVIEW:-opus}"
+BRANCH="${BRANCH:-stabilize/quality-perf}"
+AUTO_PUSH="${AUTO_PUSH:-0}"
+CLAUDE_TIMEOUT_SECONDS="${CLAUDE_TIMEOUT_SECONDS:-1800}"
+LOG_DIR="${LOG_DIR:-.claude-loop}"
+
+mkdir -p "$LOG_DIR"
+
+# ---- Preflight --------------------------------------------------------------
+
+if [ ! -f Makefile ] || [ ! -f go.mod ]; then
+  echo "ERROR: must run from the go-clockify repo root (Makefile + go.mod required)." >&2
+  exit 2
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "ERROR: 'claude' CLI not found on PATH." >&2
+  exit 2
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "ERROR: not inside a git working tree." >&2
+  exit 2
+fi
+
+# Branch handling: switch to BRANCH if it exists, else create it from HEAD.
+# Never reset, never force-checkout, never touch main.
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
+  if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    echo "== switching to existing branch '$BRANCH' =="
+    git switch "$BRANCH"
+  else
+    echo "== creating branch '$BRANCH' from current HEAD =="
+    git switch -c "$BRANCH"
+  fi
+fi
+
+echo "== branch: $(git rev-parse --abbrev-ref HEAD) =="
+echo "== HEAD:   $(git rev-parse HEAD) =="
+
+# ---- Local loop junk ignored ------------------------------------------------
+
+GITIGNORE_CHANGED=0
+ensure_ignored() {
+  local pat="$1"
+  if [ ! -f .gitignore ] || ! grep -qxF "$pat" .gitignore 2>/dev/null; then
+    printf '%s\n' "$pat" >> .gitignore
+    GITIGNORE_CHANGED=1
+  fi
+}
+ensure_ignored ".claude-loop/"
+ensure_ignored ".bench/"
+
+if [ "$GITIGNORE_CHANGED" = "1" ]; then
+  # Only commit .gitignore if no other unstaged user files would be swept up.
+  OTHER_DIRTY="$(git status --porcelain | awk '$2 != ".gitignore"' | wc -l | tr -d ' ')"
+  if [ "$OTHER_DIRTY" = "0" ]; then
+    git add .gitignore
+    git commit -m "chore: ignore loop artifacts (.claude-loop, .bench)"
+  else
+    echo "== .gitignore updated; other changes present, leaving uncommitted =="
+  fi
+fi
+
+# ---- Claude runner with timeout --------------------------------------------
+
+run_claude() {
+  # run_claude <model> <prompt_file> <log_file>
+  local model="$1"
+  local prompt_file="$2"
+  local log_file="$3"
+
+  if [ ! -f "$prompt_file" ]; then
+    echo "ERROR: prompt file not found: $prompt_file" >&2
+    return 2
+  fi
+
+  echo "== claude run model=$model timeout=${CLAUDE_TIMEOUT_SECONDS}s log=$log_file =="
+
+  local prompt
+  prompt="$(cat "$prompt_file")"
+
+  set +e
+  (
+    claude --permission-mode bypassPermissions --model "$model" -p "$prompt" 2>&1 &
+    local cpid=$!
+
+    (
+      sleep "$CLAUDE_TIMEOUT_SECONDS"
+      if kill -0 "$cpid" 2>/dev/null; then
+        echo "== TIMEOUT after ${CLAUDE_TIMEOUT_SECONDS}s; terminating claude PID $cpid ==" >&2
+        kill -TERM "$cpid" 2>/dev/null || true
+        sleep 3
+        kill -KILL "$cpid" 2>/dev/null || true
+      fi
+    ) &
+    local wpid=$!
+
+    wait "$cpid"
+    local crc=$?
+    kill "$wpid" 2>/dev/null || true
+    wait "$wpid" 2>/dev/null || true
+    exit "$crc"
+  ) | tee "$log_file"
+  local rc=${PIPESTATUS[0]}
+  set -e
+
+  echo "== claude run exit rc=$rc (143/137 typically => timeout) =="
+  return "$rc"
+}
+
+# ---- Helper: commit any uncommitted changes from a pass ---------------------
+
+commit_loop_changes() {
+  local pass_num="$1"
+
+  # Anything to commit? (modified, staged, or untracked)
+  if git diff --quiet && git diff --cached --quiet \
+     && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+    return 0
+  fi
+
+  echo "== committing uncommitted changes from pass $pass_num =="
+  git add -A
+  # Defensive: never sweep loop artifacts even if .gitignore was bypassed.
+  git restore --staged .claude-loop .bench 2>/dev/null || true
+
+  if git diff --cached --quiet; then
+    echo "== nothing staged after unstaging loop artifacts =="
+    return 0
+  fi
+
+  git commit -m "chore(loop): stabilization pass $pass_num"
+}
+
+# ---- Implementation + review loop ------------------------------------------
+
+for i in $(seq 1 "$MAX_PASSES"); do
+  echo
+  echo "============================================================"
+  echo "== Pass $i / $MAX_PASSES                                     "
+  echo "============================================================"
+
+  BEFORE_SHA="$(git rev-parse HEAD)"
+  PROMPT_FILE="$LOG_DIR/prompt-$i.txt"
+  PASS_LOG="$LOG_DIR/pass-$i.log"
+
+  cat > "$PROMPT_FILE" <<'EOF'
+You are running an autonomous stabilization+optimization pass on the
+go-clockify repo. You may edit files and commit. You will be reviewed
+afterwards by a stricter model, so keep changes narrow and defensible.
+
+Hard rules (do NOT violate any):
+- Fix exactly ONE issue or perform exactly ONE low-risk optimization.
+- Stabilize before optimizing.
+- Do NOT weaken auth, audit, policy, dry-run, rate-limit, validation,
+  MCP protocol behavior, or the stdlib-only default build.
+- Do NOT do broad refactors or unrelated cleanup.
+- No placeholder code, no `// TODO later`, no stub returns.
+- Generated docs/catalog/config tables must be regenerated via repo
+  commands, never hand-edited.
+- Stop after one completed change.
+
+Workflow:
+1. Run `git status` to see the working tree.
+2. Run `make check`.
+3. If `make check` FAILS:
+   - Fix the FIRST root cause only.
+   - Re-run `make check` until it passes.
+   - Commit the fix with a useful conventional-commit message.
+   - Stop.
+4. Else run `make release-check`.
+5. If `make release-check` FAILS:
+   - Fix the FIRST root cause only.
+   - Re-run the failing sub-target, then `make check`, then
+     `make release-check`.
+   - Commit the fix with a useful conventional-commit message.
+   - Stop.
+6. Else if `.bench/baseline.txt` does NOT exist:
+   - Run `make bench BENCH_OUT=.bench/baseline.txt`.
+   - Note: `.bench/` is gitignored — there is nothing to commit here.
+   - Stop.
+7. Else perform exactly ONE low-risk optimization:
+   - Identify a concrete, narrow target (a hot path, an allocation,
+     a redundant computation). State it clearly in the output.
+   - Make the change.
+   - Run targeted tests (the package(s) you touched, with -race).
+   - Run `make check`.
+   - Run `make verify-bench`.
+   - Keep ONLY if benchmarks improve (or the code is meaningfully
+     simpler with no benchmark regression). Otherwise revert in-tree
+     and stop with a clear "no-op pass" message.
+   - Commit the kept change with a useful conventional-commit message
+     (subject + body; body ends with `Why:` and `Verified:` lines as
+     this repo's convention).
+   - Stop.
+
+At the end print:
+- one-line summary of what changed
+- commit SHA if you committed
+- the gate commands you ran and their pass/fail
+- any benchmark deltas if a perf change was attempted
+EOF
+
+  # Run the implementation pass. Don't abort the script on claude rc;
+  # we still want to inspect any changes it made.
+  set +e
+  run_claude "$MODEL_IMPL" "$PROMPT_FILE" "$PASS_LOG"
+  IMPL_RC=$?
+  set -e
+
+  if [ "$IMPL_RC" -ne 0 ]; then
+    echo "== impl pass $i exited rc=$IMPL_RC (timeout or claude error) =="
+    echo "== inspect: $PASS_LOG =="
+    # Still try to commit any local edits Claude made before dying.
+  fi
+
+  # Commit anything Claude left uncommitted.
+  commit_loop_changes "$i"
+
+  AFTER_SHA="$(git rev-parse HEAD)"
+
+  if [ "$AFTER_SHA" = "$BEFORE_SHA" ]; then
+    echo "== pass $i produced no commit; ending loop early =="
+    break
+  fi
+
+  # ---- Review pass ----------------------------------------------------------
+
+  REVIEW_PROMPT="$LOG_DIR/review-$i.txt"
+  REVIEW_LOG="$LOG_DIR/review-$i.log"
+
+  cat > "$REVIEW_PROMPT" <<EOF
+You are reviewing commit $AFTER_SHA in the go-clockify repo as a strict
+Go / MCP / security / performance reviewer. DO NOT edit any files.
+
+Compare the commit against its parent:
+  git show --stat $AFTER_SHA
+  git show $AFTER_SHA
+
+Evaluate:
+- behavior equivalence
+- MCP protocol compatibility
+- auth safety
+- audit safety
+- policy / risk-class semantics
+- dry-run semantics
+- rate-limit semantics
+- input validation and error clarity
+- concurrency / race risks
+- memory lifetime risks
+- benchmark validity (if this is a perf change)
+- missing tests
+- generated docs / tool catalog / config-table parity
+
+Return EXACTLY this format and nothing else after it:
+
+VERDICT: KEEP or BLOCKER or REVERT
+
+BLOCKERS:
+- ...
+
+NON_BLOCKERS:
+- ...
+
+MISSING_TESTS:
+- ...
+
+RECOMMENDED_COMMANDS:
+- ...
+EOF
+
+  set +e
+  run_claude "$MODEL_REVIEW" "$REVIEW_PROMPT" "$REVIEW_LOG"
+  REVIEW_RC=$?
+  set -e
+
+  if [ "$REVIEW_RC" -ne 0 ]; then
+    echo "== review pass exited rc=$REVIEW_RC; treating as inconclusive =="
+    echo "== inspect: $REVIEW_LOG =="
+    echo "== stopping loop for human review =="
+    exit 1
+  fi
+
+  if grep -Eq "^VERDICT: (BLOCKER|REVERT)" "$REVIEW_LOG"; then
+    echo
+    echo "!! Reviewer returned BLOCKER or REVERT verdict on commit $AFTER_SHA"
+    echo "!! Review log: $REVIEW_LOG"
+    echo "!! NOT auto-reverting. Inspect, then either revert manually or amend."
+    exit 1
+  fi
+
+  # ---- Post-review gates ----------------------------------------------------
+
+  echo "== post-review gates after pass $i =="
+  if ! make check; then
+    echo "ERROR: post-review 'make check' failed after commit $AFTER_SHA" >&2
+    exit 1
+  fi
+  if ! make release-check; then
+    echo "ERROR: post-review 'make release-check' failed after commit $AFTER_SHA" >&2
+    exit 1
+  fi
+
+  if [ "$AUTO_PUSH" = "1" ]; then
+    echo "== AUTO_PUSH=1: pushing $BRANCH =="
+    git push -u origin "$BRANCH"
+  else
+    echo "== AUTO_PUSH=0: not pushing (set AUTO_PUSH=1 to enable) =="
+  fi
+
+  echo "== pass $i complete =="
+done
+
+# ---- Final review -----------------------------------------------------------
+
+echo
+echo "============================================================"
+echo "== Final release review                                     "
+echo "============================================================"
+
+FINAL_PROMPT="$LOG_DIR/final-review-prompt.txt"
+FINAL_LOG="$LOG_DIR/final-review.log"
+
+cat > "$FINAL_PROMPT" <<'EOF'
+You are doing a final release review of the go-clockify repo.
+
+DO NOT edit code unless you find a CONCRETE release blocker — and even
+then, narrow the change to the minimum required to unblock release.
+
+Run, in order:
+  git status
+  make check
+  make release-check
+  make verify-bench
+  go test -tags=grpc ./...
+
+Then create FINAL_STABILIZATION_REPORT.md at the repo root containing:
+- Verdict: SHIP or DO NOT SHIP
+- Commands you ran and pass/fail for each
+- Benchmark result summary (verify-bench output highlights)
+- Blockers (each with file:line and rationale)
+- Non-blockers (deferred items)
+- Remaining risks
+- Suggested release notes (1-paragraph summary + bullet list)
+
+Keep the report tight; this is a shippability signal, not a novel.
+EOF
+
+set +e
+run_claude "$MODEL_REVIEW" "$FINAL_PROMPT" "$FINAL_LOG"
+FINAL_RC=$?
+set -e
+
+if [ "$FINAL_RC" -ne 0 ]; then
+  echo "== final review exited rc=$FINAL_RC; inspect $FINAL_LOG =="
+fi
+
+# Commit only the report file if it was created/modified.
+if [ -f FINAL_STABILIZATION_REPORT.md ] \
+   && (! git diff --quiet -- FINAL_STABILIZATION_REPORT.md \
+       || git ls-files --others --exclude-standard --error-unmatch \
+            FINAL_STABILIZATION_REPORT.md >/dev/null 2>&1); then
+  git add FINAL_STABILIZATION_REPORT.md
+  if ! git diff --cached --quiet -- FINAL_STABILIZATION_REPORT.md; then
+    git commit -m "docs: final stabilization report"
+  fi
+fi
+
+if [ "$AUTO_PUSH" = "1" ]; then
+  git push -u origin "$BRANCH" || true
+fi
+
+# ---- Summary ----------------------------------------------------------------
+
+echo
+echo "============================================================"
+echo "== Loop finished                                             "
+echo "============================================================"
+echo "Branch:     $(git rev-parse --abbrev-ref HEAD)"
+echo "Recent commits:"
+git log --oneline -5
+echo
+echo "Working tree status:"
+git status
+echo
+echo "Logs:       $LOG_DIR"
+echo "AUTO_PUSH:  $AUTO_PUSH"

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -13,6 +13,7 @@
 #   *.swp / *.swo / *~                  — editor swap/backup files
 #   *.orig                              — merge leftovers
 #   coverage.out / *.prof                — build/profile artefacts
+#   *.test / *.exe                      — compiled Go test binaries and Windows executables
 #
 # Usage:
 #   bash scripts/check-repo-hygiene.sh
@@ -27,7 +28,7 @@ set -euo pipefail
 
 echo "== repo-hygiene =="
 
-pattern='(^|/)(\.DS_Store|Thumbs\.db|desktop\.ini|coverage\.out)$|\.(swp|swo|orig|prof)$|~$'
+pattern='(^|/)(\.DS_Store|Thumbs\.db|desktop\.ini|coverage\.out)$|\.(swp|swo|orig|prof|test|exe)$|~$'
 
 offenders=$(git ls-files | grep -E "$pattern" || true)
 


### PR DESCRIPTION
## Summary
- Fixes benchmark instability in rate-limit/enforcement benchmark paths.
- Adds autonomous Claude Code stabilization loop script.
- Ignores local loop artifacts via .gitignore.
- Fixes Docker PR image smoke startup by explicitly setting MCP_ALLOW_ANY_ORIGIN=1 for the strict-host-check test container.

## Verification
- make check
- make release-check
- targeted benchmark validation
- local Docker smoke reproduction: /health 200, /ready 503, /metrics auth checks OK
- bash -n run_claude_stabilize_loop.sh

## Notes
The automation script uses Claude Code with --permission-mode bypassPermissions and should only be run inside this repo/worktree.