### PR TITLE
fix(tools): list_invoices send ?statuses= not ?status= (SUMMARY #10)

### DIFF
--- a/docs/tool-catalog.json
+++ b/docs/tool-catalog.json
@@ -5937,6 +5937,10 @@
             "maximum": 200,
             "minimum": 1,
             "type": "integer"
+          },
+          "status": {
+            "description": "Filter by status (e.g. PAID, SENT, DRAFT)",
+            "type": "string"
           }
         },
         "type": "object"

--- a/internal/tools/tier2_invoices.go
+++ b/internal/tools/tier2_invoices.go
@@ -41,6 +41,7 @@ func invoiceHandlers(s *Service) []mcp.ToolDescriptor {
 			"properties": map[string]any{
 				"page":      map[string]any{"type": "integer", "description": "Page number (default 1)"},
 				"page_size": map[string]any{"type": "integer", "description": "Items per page (default 50)"},
+				"status":    map[string]any{"type": "string", "description": "Filter by status (e.g. PAID, SENT, DRAFT)"},
 			},
 		}), ReadOnlyHint: true, IdempotentHint: true, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.listInvoices(ctx, args)
@@ -210,10 +211,16 @@ func (s *Service) listInvoices(ctx context.Context, args map[string]any) (Result
 		Total    int              `json:"total"`
 		Invoices []map[string]any `json:"invoices"`
 	}
-	if err := s.Client.Get(ctx, path, map[string]string{
+	query := map[string]string{
 		"page":      fmt.Sprintf("%d", page),
 		"page-size": fmt.Sprintf("%d", pageSize),
-	}, &envelope); err != nil {
+	}
+	// Wire param is `statuses` (plural) — verified by clockify-api-probe-lab.
+	// See PR #53 SUMMARY #10. The arg name `status` matches invoice_report.
+	if v := stringArg(args, "status"); v != "" {
+		query["statuses"] = v
+	}
+	if err := s.Client.Get(ctx, path, query, &envelope); err != nil {
 		return ResultEnvelope{}, err
 	}
 	return ok("clockify_list_invoices", envelope.Invoices, map[string]any{

--- a/internal/tools/tier2_invoices_test.go
+++ b/internal/tools/tier2_invoices_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -252,6 +253,40 @@ func TestTier2_Invoices_GroupRegistration(t *testing.T) {
 		if d.Handler == nil {
 			t.Fatalf("missing handler: %s", d.Tool.Name)
 		}
+	}
+}
+
+// TestTier2_Invoices_ListSendsStatusesNotStatus pins SUMMARY #10:
+// when the caller passes `status`, the handler must emit ?statuses=
+// (plural) upstream and must NOT emit ?status=. Upstream wire name
+// verified by clockify-api-probe-lab 2026-05-02.
+func TestTier2_Invoices_ListSendsStatusesNotStatus(t *testing.T) {
+	var capturedQuery url.Values
+	client, cleanup := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/workspaces/ws1/invoices" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		capturedQuery = r.URL.Query()
+		respondJSON(t, w, map[string]any{
+			"total":    1,
+			"invoices": []map[string]any{{"id": "inv1", "status": "PAID"}},
+		})
+	})
+	defer cleanup()
+	svc := New(client, "ws1")
+
+	res, err := svc.listInvoices(context.Background(), map[string]any{
+		"status":    "PAID",
+		"page":      1,
+		"page_size": 50,
+	})
+	mustOK(t, res, err, "clockify_list_invoices")
+
+	if got := capturedQuery.Get("statuses"); got != "PAID" {
+		t.Fatalf("expected ?statuses=PAID, got %q (full query=%q)", got, capturedQuery.Encode())
+	}
+	if got := capturedQuery.Get("status"); got != "" {
+		t.Fatalf("must not send legacy ?status, got %q (full query=%q)", got, capturedQuery.Encode())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a `status` filter argument to `clockify_list_invoices` and emits it upstream as `?statuses=` (plural) — the wire name Clockify actually accepts on `GET /workspaces/{ws}/invoices`.
- Pins the contract with a dedicated unit test (`TestTier2_Invoices_ListSendsStatusesNotStatus`) that asserts both halves: `?statuses=<value>` present **and** `?status=<value>` absent.
- Closes deferred item **#10** from PR #53's "Still remaining (out of scope, follow-up PRs):" list (`list_invoices ?status= → ?statuses= rename`).

## Why

The previous descriptor exposed no status filter at all; the rename in PR #53's deferred list is therefore both a feature add and a wire-format guard. Without it, any future caller using the obvious singular name would silently no-op against the upstream's plural parameter and return unfiltered pages.

The wire name was verified via `clockify-api-probe-lab` against the sacrificial workspace on 2026-05-02 (the same probe-lab finding that anchors the existing envelope-shape comment in `listInvoices`). The arg name follows the `clockify_invoice_report` convention established at `internal/tools/tier2_invoices.go:594-595` (input \`status\` → wire \`statuses\`).

## Scope

- **Touched:** `internal/tools/tier2_invoices.go` (descriptor + handler), `internal/tools/tier2_invoices_test.go` (new test + `net/url` import), `docs/tool-catalog.json` (regenerated).
- **Deliberately not touched:** `shared_reports`, `scheduling`, `expenses`, `holidays`, `custom_fields`, `docs/launch-candidate-checklist.md`, `.github/workflows/live-contract.yml`. Existing tests `TestTier2_Invoices_FullSweep` and `TestTier2_Invoices_GroupRegistration` are unmodified and stay green.
- **Out of scope by design:** documenting `amount` / `unit_price` raw-unit semantics. The repo has no existing fixture, comment, or doc that pins decimal-vs-minor-unit behavior; inventing it would violate the \"do not invent conversion behavior\" rule. Tracked separately as PR #53's other deferred item.

## Test plan

- [x] `go test -race -run TestTier2_Invoices ./internal/tools/...`
- [x] **Drift check** (per `AGENTS.md` §3): flipped \`query[\"statuses\"] = v\` to \`query[\"status\"] = v\`. New test failed with \`expected ?statuses=PAID, got \"\" (full query=\"page=1&page-size=50&status=PAID\")\`. Restored, green.
- [x] \`make check\` (fmt + vet + test) — all packages green
- [x] \`make doc-parity\` — OK
- [x] \`make config-doc-parity\` — OK
- [x] \`make catalog-drift\` — OK (no drift)
- [x] \`git diff --check\` — clean