### PR TITLE
fix(shared_reports): correct write/export wiring (lab-pinned SUMMARY #24-#27)

### DIFF
--- a/docs/tool-catalog.json
+++ b/docs/tool-catalog.json
@@ -7085,9 +7085,33 @@
       "input_schema": {
         "additionalProperties": false,
         "properties": {
-          "filters": {
-            "additionalProperties": false,
-            "description": "Optional filter object (project IDs, user IDs, date range, etc.)",
+          "filter": {
+            "additionalProperties": true,
+            "description": "Required filter object. Live-required: exportType (JSON_V1|PDF|CSV|XLSX), dateRangeStart (ISO 8601), dateRangeEnd (ISO 8601). Optional: summaryFilter / detailedFilter / weeklyFilter / projects / users / etc.",
+            "properties": {
+              "dateRangeEnd": {
+                "description": "ISO 8601 timestamp",
+                "type": "string"
+              },
+              "dateRangeStart": {
+                "description": "ISO 8601 timestamp",
+                "type": "string"
+              },
+              "exportType": {
+                "enum": [
+                  "JSON_V1",
+                  "PDF",
+                  "CSV",
+                  "XLSX"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "exportType",
+              "dateRangeStart",
+              "dateRangeEnd"
+            ],
             "type": "object"
           },
           "name": {
@@ -7095,13 +7119,35 @@
             "type": "string"
           },
           "report_type": {
-            "description": "Report type (e.g. SUMMARY, DETAILED, WEEKLY)",
+            "description": "Report type — common: SUMMARY, DETAILED, WEEKLY. Full upstream enum below.",
+            "enum": [
+              "DETAILED",
+              "WEEKLY",
+              "SUMMARY",
+              "SCHEDULED",
+              "EXPENSE_DETAILED",
+              "EXPENSE_RECEIPT",
+              "PTO_REQUESTS",
+              "PTO_BALANCE",
+              "ATTENDANCE",
+              "INVOICE_EXPENSE",
+              "INVOICE_TIME",
+              "PROJECT",
+              "TEAM_FULL",
+              "TEAM_LIMITED",
+              "TEAM_GROUPS",
+              "INVOICES",
+              "KIOSK_PIN_LIST",
+              "KIOSK_ASSIGNEES",
+              "USER_DATA_EXPORT"
+            ],
             "type": "string"
           }
         },
         "required": [
           "name",
-          "report_type"
+          "report_type",
+          "filter"
         ],
         "type": "object"
       },
@@ -7182,7 +7228,7 @@
     },
     {
       "name": "clockify_export_shared_report",
-      "description": "Export a shared report in a specified format",
+      "description": "Export a shared report. JSON returns the decoded object; PDF/CSV/XLSX return a binary-aware envelope with base64-encoded body.",
       "group": "shared_reports",
       "tier": 2,
       "read_only": true,
@@ -7195,7 +7241,14 @@
         "additionalProperties": false,
         "properties": {
           "format": {
-            "description": "Export format: csv, json, pdf, or excel (default json)",
+            "description": "Export format. Accepts: json (default, returns decoded JSON_V1), pdf, csv, xlsx (alias: excel).",
+            "enum": [
+              "json",
+              "pdf",
+              "csv",
+              "xlsx",
+              "excel"
+            ],
             "type": "string"
           },
           "report_id": {
@@ -7332,7 +7385,7 @@
     },
     {
       "name": "clockify_update_shared_report",
-      "description": "Update an existing shared report",
+      "description": "Update an existing shared report (PUT semantics is merge — partial body preserves the existing filter)",
       "group": "shared_reports",
       "tier": 2,
       "read_only": false,
@@ -7344,8 +7397,9 @@
       "input_schema": {
         "additionalProperties": false,
         "properties": {
-          "filters": {
-            "additionalProperties": false,
+          "filter": {
+            "additionalProperties": true,
+            "description": "Optional filter object — same shape as create. Send only the keys you want to change.",
             "type": "object"
           },
           "name": {
@@ -7355,6 +7409,27 @@
             "type": "string"
           },
           "report_type": {
+            "enum": [
+              "DETAILED",
+              "WEEKLY",
+              "SUMMARY",
+              "SCHEDULED",
+              "EXPENSE_DETAILED",
+              "EXPENSE_RECEIPT",
+              "PTO_REQUESTS",
+              "PTO_BALANCE",
+              "ATTENDANCE",
+              "INVOICE_EXPENSE",
+              "INVOICE_TIME",
+              "PROJECT",
+              "TEAM_FULL",
+              "TEAM_LIMITED",
+              "TEAM_GROUPS",
+              "INVOICES",
+              "KIOSK_PIN_LIST",
+              "KIOSK_ASSIGNEES",
+              "USER_DATA_EXPORT"
+            ],
             "type": "string"
           }
         },

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -144,10 +144,10 @@ re-run `make gen-tool-catalog` after changing any tool descriptor.
 |------|-----------|-------------|------------|------|-------------|
 | `clockify_create_shared_report` | no | no | no | `write` | Create a new shared report |
 | `clockify_delete_shared_report` | no | yes | no | `destructive` | Delete a shared report by ID |
-| `clockify_export_shared_report` | yes | no | yes | `read` | Export a shared report in a specified format |
+| `clockify_export_shared_report` | yes | no | yes | `read` | Export a shared report. JSON returns the decoded object; PDF/CSV/XLSX return a binary-aware envelope with base64-encoded body. |
 | `clockify_get_shared_report` | yes | no | yes | `read` | Get a single shared report by ID |
 | `clockify_list_shared_reports` | yes | no | yes | `read` | List shared reports in the workspace with pagination |
-| `clockify_update_shared_report` | no | no | no | `write` | Update an existing shared report |
+| `clockify_update_shared_report` | no | no | no | `write` | Update an existing shared report (PUT semantics is merge — partial body preserves the existing filter) |
 
 ### `time_off`
 

--- a/internal/clockify/client.go
+++ b/internal/clockify/client.go
@@ -177,6 +177,29 @@ func (c *Client) DeleteReports(ctx context.Context, path string) error {
 	return c.doJSON(ctx, c.ReportsBaseURL(), http.MethodDelete, path, nil, nil, nil)
 }
 
+// RawResponse is the binary-aware envelope returned by GetReportsRaw —
+// the raw response bytes plus enough header context for callers to
+// recover Content-Type and Content-Disposition (filename). Used by the
+// shared-reports export endpoint where the upstream returns binary
+// (PDF/XLSX) or non-JSON text (CSV).
+type RawResponse struct {
+	Header http.Header
+	Body   []byte
+}
+
+// GetReportsRaw is the binary-aware sibling of GetReports. It runs the
+// same retry/tracing/metrics pipeline but skips the JSON unmarshal,
+// exposing the raw body bytes and response headers so callers can
+// inspect Content-Type and Content-Disposition. Use for export
+// endpoints; use GetReports for JSON-shaped reads.
+func (c *Client) GetReportsRaw(ctx context.Context, path string, query map[string]string) (*RawResponse, error) {
+	raw := &RawResponse{}
+	if err := c.doRequest(ctx, c.ReportsBaseURL(), http.MethodGet, path, query, "", nil, raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
 // PostMultipart performs a POST with a multipart/form-data body. Each
 // form key maps to one or more values; multi-value keys are written as
 // repeated form fields under the same name (the encoding the Clockify
@@ -411,6 +434,28 @@ func (c *Client) doOnce(ctx context.Context, baseURL, method, path, endpoint str
 
 	if out == nil {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, responseDrainLimit))
+		return nil
+	}
+	// Binary-aware path: when the caller wants the raw bytes (e.g.
+	// shared-reports PDF/CSV/XLSX export), read into a fresh buffer
+	// and stash headers — no JSON unmarshal. Same size cap as the
+	// JSON path so an oversize binary still surfaces a clear error.
+	if raw, ok := out.(*RawResponse); ok {
+		respBuf := getBodyBuf()
+		defer putBodyBuf(respBuf)
+		n, err := io.Copy(respBuf, io.LimitReader(resp.Body, maxResponseBody+1))
+		if err != nil {
+			return err
+		}
+		if n > maxResponseBody {
+			metrics.ClockifyResponsesOversizeTotal.Inc(method)
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, responseDrainLimit))
+			return fmt.Errorf("clockify response too large: > %d bytes (method=%s path=%s)", maxResponseBody, method, path)
+		}
+		body := make([]byte, n)
+		copy(body, respBuf.Bytes())
+		raw.Header = resp.Header.Clone()
+		raw.Body = body
 		return nil
 	}
 	// Read the body into a pooled buffer, then unmarshal. Using

--- a/internal/clockify/client_test.go
+++ b/internal/clockify/client_test.go
@@ -756,3 +756,85 @@ func contains(haystack, needle string) bool {
 	}
 	return false
 }
+
+// ---------------------------------------------------------------------------
+// GetReportsRaw / RawResponse coverage. The shared-reports export
+// handler depends on these; the JSON-mode siblings are well-covered
+// via the Get/Post/Put/Delete tests above, but the raw branch in
+// doOnce was uncovered until 2026-05-03.
+// ---------------------------------------------------------------------------
+
+func TestGetReportsRawSuccessReturnsBytesAndHeaders(t *testing.T) {
+	pdfMagic := []byte{'%', 'P', 'D', 'F'}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/shared-reports/abc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("exportType") != "PDF" {
+			t.Fatalf("missing ?exportType=PDF query: %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/pdf")
+		w.Header().Set("Content-Disposition", "filename=foo.pdf")
+		_, _ = w.Write(pdfMagic)
+	}))
+	defer ts.Close()
+
+	c := NewClient("test-key", ts.URL, 5*time.Second, 0)
+	raw, err := c.GetReportsRaw(context.Background(), "/shared-reports/abc", map[string]string{"exportType": "PDF"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := raw.Header.Get("Content-Type"); got != "application/pdf" {
+		t.Fatalf("Content-Type want application/pdf, got %q", got)
+	}
+	if got := raw.Header.Get("Content-Disposition"); got != "filename=foo.pdf" {
+		t.Fatalf("Content-Disposition want filename=foo.pdf, got %q", got)
+	}
+	if string(raw.Body) != string(pdfMagic) {
+		t.Fatalf("body bytes mismatch: want %v got %v", pdfMagic, raw.Body)
+	}
+}
+
+func TestGetReportsRawAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":404,"message":"NOT FOUND"}`))
+	}))
+	defer ts.Close()
+
+	c := NewClient("test-key", ts.URL, 5*time.Second, 0)
+	raw, err := c.GetReportsRaw(context.Background(), "/shared-reports/missing", nil)
+	if err == nil {
+		t.Fatalf("expected error on 404, got nil (raw=%v)", raw)
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestGetReportsRawEmptyBodyOK(t *testing.T) {
+	// Some Reports endpoints reply 200 with no body (e.g. zero-byte
+	// CSV — rare but observed). The raw branch must tolerate it,
+	// returning an empty Body slice rather than erroring.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := NewClient("test-key", ts.URL, 5*time.Second, 0)
+	raw, err := c.GetReportsRaw(context.Background(), "/shared-reports/empty", map[string]string{"exportType": "CSV"})
+	if err != nil {
+		t.Fatalf("unexpected error on empty body: %v", err)
+	}
+	if len(raw.Body) != 0 {
+		t.Fatalf("expected empty body, got %d bytes", len(raw.Body))
+	}
+	if got := raw.Header.Get("Content-Type"); got != "text/csv" {
+		t.Fatalf("Content-Type want text/csv, got %q", got)
+	}
+}

--- a/internal/tools/tier2_shared_reports.go
+++ b/internal/tools/tier2_shared_reports.go
@@ -2,13 +2,51 @@ package tools
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/apet97/go-clockify/internal/dryrun"
 	"github.com/apet97/go-clockify/internal/mcp"
 	"github.com/apet97/go-clockify/internal/paths"
 	"github.com/apet97/go-clockify/internal/resolve"
 )
+
+// sharedReportTypes is the live-confirmed enum the upstream accepts
+// for the create/update body's "type" field (lab probe 2026-05-03,
+// fixtures/shared-reports/create-2-with-filter.json error message).
+// Documented in the JSON Schema descriptor so the AI client knows
+// the full surface; the previous handler advertised only the
+// SUMMARY/DETAILED/WEEKLY subset.
+var sharedReportTypes = []string{
+	"DETAILED", "WEEKLY", "SUMMARY", "SCHEDULED",
+	"EXPENSE_DETAILED", "EXPENSE_RECEIPT",
+	"PTO_REQUESTS", "PTO_BALANCE",
+	"ATTENDANCE", "INVOICE_EXPENSE", "INVOICE_TIME",
+	"PROJECT", "TEAM_FULL", "TEAM_LIMITED", "TEAM_GROUPS",
+	"INVOICES", "KIOSK_PIN_LIST", "KIOSK_ASSIGNEES",
+	"USER_DATA_EXPORT",
+}
+
+// sharedReportFilterSchema is the JSON Schema fragment for the
+// upstream "filter" body field (singular — the Java DTO is
+// ReportFilterV1). exportType / dateRangeStart / dateRangeEnd are
+// required by the live API; everything else is optional and accepted
+// as additional properties.
+func sharedReportFilterSchema() map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": "Required filter object. Live-required: exportType (JSON_V1|PDF|CSV|XLSX), dateRangeStart (ISO 8601), dateRangeEnd (ISO 8601). Optional: summaryFilter / detailedFilter / weeklyFilter / projects / users / etc.",
+		"required":    []string{"exportType", "dateRangeStart", "dateRangeEnd"},
+		"properties": map[string]any{
+			"exportType":     map[string]any{"type": "string", "enum": []string{"JSON_V1", "PDF", "CSV", "XLSX"}},
+			"dateRangeStart": map[string]any{"type": "string", "description": "ISO 8601 timestamp"},
+			"dateRangeEnd":   map[string]any{"type": "string", "description": "ISO 8601 timestamp"},
+		},
+		"additionalProperties": true,
+	}
+}
 
 func init() {
 	registerTier2Group(Tier2Group{
@@ -52,25 +90,25 @@ func sharedReportHandlers(s *Service) []mcp.ToolDescriptor {
 		// 3. Create shared report (RW)
 		{Tool: toolRW("clockify_create_shared_report", "Create a new shared report", map[string]any{
 			"type":     "object",
-			"required": []string{"name", "report_type"},
+			"required": []string{"name", "report_type", "filter"},
 			"properties": map[string]any{
 				"name":        map[string]any{"type": "string", "description": "Report name"},
-				"report_type": map[string]any{"type": "string", "description": "Report type (e.g. SUMMARY, DETAILED, WEEKLY)"},
-				"filters":     map[string]any{"type": "object", "description": "Optional filter object (project IDs, user IDs, date range, etc.)"},
+				"report_type": map[string]any{"type": "string", "description": "Report type — common: SUMMARY, DETAILED, WEEKLY. Full upstream enum below.", "enum": sharedReportTypes},
+				"filter":      sharedReportFilterSchema(),
 			},
 		}), ReadOnlyHint: false, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.createSharedReport(ctx, args)
 		}},
 
 		// 4. Update shared report (RW)
-		{Tool: toolRW("clockify_update_shared_report", "Update an existing shared report", map[string]any{
+		{Tool: toolRW("clockify_update_shared_report", "Update an existing shared report (PUT semantics is merge — partial body preserves the existing filter)", map[string]any{
 			"type":     "object",
 			"required": []string{"report_id"},
 			"properties": map[string]any{
 				"report_id":   map[string]any{"type": "string"},
 				"name":        map[string]any{"type": "string"},
-				"report_type": map[string]any{"type": "string"},
-				"filters":     map[string]any{"type": "object"},
+				"report_type": map[string]any{"type": "string", "enum": sharedReportTypes},
+				"filter":      map[string]any{"type": "object", "description": "Optional filter object — same shape as create. Send only the keys you want to change.", "additionalProperties": true},
 			},
 		}), ReadOnlyHint: false, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.updateSharedReport(ctx, args)
@@ -88,13 +126,20 @@ func sharedReportHandlers(s *Service) []mcp.ToolDescriptor {
 			return s.deleteSharedReport(ctx, args)
 		}},
 
-		// 6. Export shared report (RO)
-		{Tool: toolRO("clockify_export_shared_report", "Export a shared report in a specified format", map[string]any{
+		// 6. Export shared report (RO).
+		// Lab probe (2026-05-03) confirmed the export path is the
+		// bare /shared-reports/{id} (no workspace) plus
+		// ?exportType=PDF|CSV|XLSX|JSON_V1; the previously assumed
+		// /export segment returns 404. Non-JSON formats return binary
+		// (PDF/XLSX) or text (CSV) — the handler returns a binary-aware
+		// envelope {contentType, filename, bytes, body(base64)} for
+		// those, and a decoded JSON object for JSON_V1.
+		{Tool: toolRO("clockify_export_shared_report", "Export a shared report. JSON returns the decoded object; PDF/CSV/XLSX return a binary-aware envelope with base64-encoded body.", map[string]any{
 			"type":     "object",
 			"required": []string{"report_id"},
 			"properties": map[string]any{
 				"report_id": map[string]any{"type": "string"},
-				"format":    map[string]any{"type": "string", "description": "Export format: csv, json, pdf, or excel (default json)"},
+				"format":    map[string]any{"type": "string", "description": "Export format. Accepts: json (default, returns decoded JSON_V1), pdf, csv, xlsx (alias: excel).", "enum": []string{"json", "pdf", "csv", "xlsx", "excel"}},
 			},
 		}), ReadOnlyHint: true, IdempotentHint: true, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.exportSharedReport(ctx, args)
@@ -150,10 +195,13 @@ func (s *Service) getSharedReport(ctx context.Context, args map[string]any) (Res
 		return ResultEnvelope{}, err
 	}
 
-	// Single-get path has no workspace segment per
-	// findings/shared-reports.md (the workspace-prefixed path 404s
-	// even on the reports host). exportType=JSON_V1 forces a JSON
-	// body — other values return PDF/CSV/XLSX.
+	// Single-get path has no workspace segment. The workspace-prefixed
+	// per-id path (/v1/workspaces/{ws}/shared-reports/{id}) DOES exist
+	// — PUT and DELETE land there — but it returns 405 for GET. The
+	// bare-id path is the only GET-compatible route. Confirmed live
+	// 2026-05-03; see findings/shared-reports.md. exportType=JSON_V1
+	// forces a JSON body; other values return PDF/CSV/XLSX (handled
+	// in exportSharedReport, not here).
 	path := "/shared-reports/" + reportID
 	query := map[string]string{"exportType": "JSON_V1"}
 	var report map[string]any
@@ -169,17 +217,23 @@ func (s *Service) createSharedReport(ctx context.Context, args map[string]any) (
 	if name == "" || reportType == "" {
 		return ResultEnvelope{}, fmt.Errorf("name and report_type are required")
 	}
+	filter, hasFilter := args["filter"].(map[string]any)
+	if !hasFilter || filter == nil {
+		return ResultEnvelope{}, fmt.Errorf("filter is required (must include exportType, dateRangeStart, dateRangeEnd)")
+	}
 	wsID, err := s.ResolveWorkspaceID(ctx)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
 
+	// Body keys match the upstream Java DTOs: "type" (not
+	// reportType — server rejects reportType with 400) and "filter"
+	// (singular, ReportFilterV1). See findings/shared-reports.md
+	// changes #24-#27.
 	body := map[string]any{
-		"name":       name,
-		"reportType": reportType,
-	}
-	if filters, ok := args["filters"].(map[string]any); ok {
-		body["filters"] = filters
+		"name":   name,
+		"type":   reportType,
+		"filter": filter,
 	}
 
 	path, err := paths.Workspace(wsID, "shared-reports")
@@ -203,15 +257,18 @@ func (s *Service) updateSharedReport(ctx context.Context, args map[string]any) (
 		return ResultEnvelope{}, err
 	}
 
+	// PUT semantics is merge — partial body preserves the existing
+	// filter (live-confirmed 2026-05-03). Send only the fields the
+	// caller passed; mirror the create-side body keys (type / filter).
 	body := map[string]any{}
 	if v := stringArg(args, "name"); v != "" {
 		body["name"] = v
 	}
 	if v := stringArg(args, "report_type"); v != "" {
-		body["reportType"] = v
+		body["type"] = v
 	}
-	if filters, ok := args["filters"].(map[string]any); ok {
-		body["filters"] = filters
+	if filter, hasFilter := args["filter"].(map[string]any); hasFilter {
+		body["filter"] = filter
 	}
 
 	path, err := paths.Workspace(wsID, "shared-reports", reportID)
@@ -234,15 +291,17 @@ func (s *Service) deleteSharedReport(ctx context.Context, args map[string]any) (
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
-	reportPath, err := paths.Workspace(wsID, "shared-reports", reportID)
+	deletePath, err := paths.Workspace(wsID, "shared-reports", reportID)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
 
-	// Dry-run: fetch the report for preview, don't delete.
+	// Dry-run preview: fetch via the bare-id GET (the only GET-
+	// compatible per-id route — workspace-prefixed GET is 405). Don't
+	// delete.
 	if dryrun.Enabled(args) {
 		var report map[string]any
-		if err := s.Client.GetReports(ctx, reportPath, nil, &report); err != nil {
+		if err := s.Client.GetReports(ctx, "/shared-reports/"+reportID, map[string]string{"exportType": "JSON_V1"}, &report); err != nil {
 			return ResultEnvelope{}, err
 		}
 		return ResultEnvelope{
@@ -253,13 +312,57 @@ func (s *Service) deleteSharedReport(ctx context.Context, args map[string]any) (
 		}, nil
 	}
 
-	if err := s.Client.DeleteReports(ctx, reportPath); err != nil {
+	if err := s.Client.DeleteReports(ctx, deletePath); err != nil {
 		return ResultEnvelope{}, err
 	}
 	return ok("clockify_delete_shared_report", map[string]any{
 		"deleted":  true,
 		"reportId": reportID,
 	}, map[string]any{"workspaceId": wsID}), nil
+}
+
+// sharedReportExportTypeFor maps the user-facing format token to the
+// upstream exportType enum value. The upstream enum is the one
+// observed live (2026-05-03) on /v1/shared-reports/{id}?exportType=…
+// The "excel" alias preserves the historical user-facing token.
+func sharedReportExportTypeFor(format string) (exportType string, isJSON bool) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", "json", "json_v1":
+		return "JSON_V1", true
+	case "pdf":
+		return "PDF", false
+	case "csv":
+		return "CSV", false
+	case "xlsx", "excel":
+		return "XLSX", false
+	default:
+		// Unknown format — pass through verbatim and let the upstream
+		// reject. Treated as binary (non-JSON) so the handler doesn't
+		// silently base64-wrap a JSON response or vice versa.
+		return strings.ToUpper(format), false
+	}
+}
+
+// parseExportFilename extracts the filename from a Content-Disposition
+// header like "filename=Clockify_Time_Report_Summary_11%2F15%2F2023-12%2F07%2F2023.pdf".
+// Returns empty string if absent. Slashes arrive percent-encoded; we
+// URL-decode them so callers see a sensible filename.
+func parseExportFilename(cd string) string {
+	if cd == "" {
+		return ""
+	}
+	_, fn, found := strings.Cut(cd, "filename=")
+	if !found {
+		return ""
+	}
+	if before, _, hasSemi := strings.Cut(fn, ";"); hasSemi {
+		fn = before
+	}
+	fn = strings.Trim(fn, `"`)
+	if decoded, err := url.QueryUnescape(fn); err == nil {
+		return decoded
+	}
+	return fn
 }
 
 func (s *Service) exportSharedReport(ctx context.Context, args map[string]any) (ResultEnvelope, error) {
@@ -273,23 +376,45 @@ func (s *Service) exportSharedReport(ctx context.Context, args map[string]any) (
 	}
 
 	format := stringArg(args, "format")
-	if format == "" {
-		format = "json"
+	exportType, isJSON := sharedReportExportTypeFor(format)
+
+	// Bare-id path (no workspace segment). The previously assumed
+	// /workspaces/{ws}/shared-reports/{id}/export route returns 404
+	// — there is no /export segment. Live-confirmed 2026-05-03; see
+	// fixtures/shared-reports/discover_ws-prefixed-export.json
+	// (404) and export-{pdf,csv,xlsx}.{headers.txt,binary-summary.json}.
+	path := "/shared-reports/" + reportID
+	query := map[string]string{"exportType": exportType}
+
+	if isJSON {
+		var export map[string]any
+		if err := s.Client.GetReports(ctx, path, query, &export); err != nil {
+			return ResultEnvelope{}, err
+		}
+		return ok("clockify_export_shared_report", export, map[string]any{
+			"workspaceId": wsID,
+			"reportId":    reportID,
+			"format":      "json",
+			"exportType":  exportType,
+		}), nil
 	}
 
-	query := map[string]string{"format": format}
-
-	path, err := paths.Workspace(wsID, "shared-reports", reportID, "export")
+	raw, err := s.Client.GetReportsRaw(ctx, path, query)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
-	var export map[string]any
-	if err := s.Client.GetReports(ctx, path, query, &export); err != nil {
-		return ResultEnvelope{}, err
+	contentType := raw.Header.Get("Content-Type")
+	filename := parseExportFilename(raw.Header.Get("Content-Disposition"))
+	envelope := map[string]any{
+		"contentType": contentType,
+		"filename":    filename,
+		"bytes":       len(raw.Body),
+		"body":        base64.StdEncoding.EncodeToString(raw.Body),
 	}
-	return ok("clockify_export_shared_report", export, map[string]any{
+	return ok("clockify_export_shared_report", envelope, map[string]any{
 		"workspaceId": wsID,
 		"reportId":    reportID,
-		"format":      format,
+		"format":      strings.ToLower(format),
+		"exportType":  exportType,
 	}), nil
 }

--- a/internal/tools/tier2_shared_reports_dispatch_test.go
+++ b/internal/tools/tier2_shared_reports_dispatch_test.go
@@ -16,8 +16,32 @@ package tools_test
 // reports baseURL because Client.ReportsBaseURL() falls through to the
 // primary baseURL whenever the primary URL doesn't match the canonical
 // production host — see internal/clockify/client.go ReportsBaseURL.
+//
+// Write/export pinning (rev 4 — 2026-05-03 lab probes):
+//
+//   - createSharedReport must POST to the workspace-prefixed path with
+//     body keys "type" (NOT "reportType") and "filter" (NOT "filters",
+//     the upstream DTO is ReportFilterV1). filter.exportType,
+//     filter.dateRangeStart, filter.dateRangeEnd are required.
+//
+//   - updateSharedReport must PUT to the workspace-prefixed per-id path
+//     with the same body-key conventions. Bare-id PUT/PATCH both return
+//     405; the previous "everything per-id is bare" generalisation was
+//     wrong.
+//
+//   - deleteSharedReport must DELETE to the workspace-prefixed per-id
+//     path and tolerate a 204 with empty body.
+//
+//   - exportSharedReport must GET the bare /shared-reports/{id} path
+//     (no workspace) with ?exportType=PDF|CSV|XLSX|JSON_V1 (NOT a
+//     /export segment with ?format=). For non-JSON exports the handler
+//     must return a binary-aware envelope {contentType, filename,
+//     bytes, body(base64)}; JSON_V1 stays decoded as a JSON map.
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -113,5 +137,285 @@ func TestTier2Dispatch_SharedReports_Get(t *testing.T) {
 	}
 	if !strings.Contains(res.ResultText, `"id":"sr-1"`) {
 		t.Fatalf("get result missing id: %q", res.ResultText)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Write / export dispatch tests (rev 4 pin: SUMMARY changes #24-#27).
+// ---------------------------------------------------------------------------
+
+const (
+	srWriteWS         = "test-workspace"
+	srWriteCreatedID  = "sr-write-2"
+	srWriteCreateName = "ws-prefixed create"
+	srWriteRenamedTo  = "ws-prefixed rename"
+)
+
+// fakePDF is a 4-byte body the export tests use to verify the
+// binary-aware envelope. It's deliberately not JSON; if the handler
+// tries to json.Unmarshal it, the test will fail with a parse error.
+var fakePDF = []byte{'%', 'P', 'D', 'F'}
+
+// newSharedReportsWriteUpstream registers handlers that pin the four
+// write/export tools to the canonical request shapes discovered by
+// the lab on 2026-05-03 (probes/shared-reports-write.sh).
+//
+// Any request that lands on a path/method combination the lab proved
+// is wrong (bare-id PUT/PATCH/DELETE, ws-prefixed bare GET, /export
+// segment, etc.) calls t.Fatalf so a regression that re-introduces
+// the wrong wiring fails loudly.
+func newSharedReportsWriteUpstream(t *testing.T) *testharness.FakeClockify {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// CREATE — POST /workspaces/{ws}/shared-reports.
+	// Body must use "type" (not "reportType") and "filter" (not
+	// "filters"); filter must contain exportType/dateRangeStart/
+	// dateRangeEnd. Reply with the canonical create response shape.
+	mux.HandleFunc("/workspaces/"+srWriteWS+"/shared-reports", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("create: expected POST, got %s", r.Method)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("create: read body: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("create: body not JSON: %v (raw=%s)", err, string(body))
+		}
+		if _, has := got["reportType"]; has {
+			t.Fatalf("create: stale field 'reportType' present (must be 'type'); body=%s", string(body))
+		}
+		if _, has := got["filters"]; has {
+			t.Fatalf("create: stale field 'filters' present (must be 'filter'); body=%s", string(body))
+		}
+		if got["type"] == nil || got["type"] == "" {
+			t.Fatalf("create: missing required 'type'; body=%s", string(body))
+		}
+		filter, ok := got["filter"].(map[string]any)
+		if !ok {
+			t.Fatalf("create: 'filter' missing or not an object; body=%s", string(body))
+		}
+		for _, k := range []string{"exportType", "dateRangeStart", "dateRangeEnd"} {
+			if v, has := filter[k]; !has || v == nil || v == "" {
+				t.Fatalf("create: filter.%s required; body=%s", k, string(body))
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"` + srWriteCreatedID + `","workspaceId":"` + srWriteWS +
+			`","name":"` + srWriteCreateName + `","type":"SUMMARY","filter":{"exportType":"JSON_V1"}}`))
+	})
+
+	// UPDATE — PUT /workspaces/{ws}/shared-reports/{id}.
+	// DELETE — DELETE /workspaces/{ws}/shared-reports/{id}.
+	mux.HandleFunc("/workspaces/"+srWriteWS+"/shared-reports/"+srWriteCreatedID, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("update: read body: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("update: body not JSON: %v (raw=%s)", err, string(body))
+			}
+			if _, has := got["reportType"]; has {
+				t.Fatalf("update: stale field 'reportType' present (must be 'type'); body=%s", string(body))
+			}
+			if _, has := got["filters"]; has {
+				t.Fatalf("update: stale field 'filters' present (must be 'filter'); body=%s", string(body))
+			}
+			if got["name"] != srWriteRenamedTo {
+				t.Fatalf("update: expected name=%q, got %v; body=%s", srWriteRenamedTo, got["name"], string(body))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"` + srWriteCreatedID + `","workspaceId":"` + srWriteWS +
+				`","name":"` + srWriteRenamedTo + `","type":"SUMMARY","filter":{"exportType":"JSON_V1"}}`))
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			t.Fatalf("update/delete handler: GET landed on workspace-prefixed per-id path; live API returns 405. handler regression.")
+		default:
+			t.Fatalf("update/delete handler: unsupported method %s on %s", r.Method, r.URL.Path)
+		}
+	})
+
+	// EXPORT — GET /shared-reports/{id} (NO workspace segment) with
+	// ?exportType=PDF|CSV|XLSX|JSON_V1.
+	mux.HandleFunc("/shared-reports/"+srWriteCreatedID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("export: expected GET on bare-id path, got %s", r.Method)
+		}
+		exportType := r.URL.Query().Get("exportType")
+		if exportType == "" {
+			t.Fatalf("export: missing ?exportType= query (full=%q)", r.URL.RawQuery)
+		}
+		if r.URL.Query().Get("format") != "" {
+			t.Fatalf("export: stale ?format= query present (must be exportType); full=%q", r.URL.RawQuery)
+		}
+		switch exportType {
+		case "JSON_V1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"` + srWriteCreatedID + `","totals":[],"filter":{"name":"json round-trip"}}`))
+		case "PDF":
+			w.Header().Set("Content-Type", "application/pdf")
+			w.Header().Set("Content-Disposition", "filename=Clockify_Time_Report_Summary_11%2F15%2F2023-12%2F07%2F2023.pdf")
+			_, _ = w.Write(fakePDF)
+		default:
+			t.Fatalf("export: unexpected exportType %q in this test", exportType)
+		}
+	})
+
+	// Trip-wires for paths the handler must NEVER hit.
+	mux.HandleFunc("/workspaces/"+srWriteWS+"/shared-reports/"+srWriteCreatedID+"/export", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("export: handler hit /export segment (live API returns 404). regression — drop the /export suffix.")
+	})
+
+	return testharness.NewFakeClockify(t, mux)
+}
+
+func TestTier2Dispatch_SharedReports_Create(t *testing.T) {
+	upstream := newSharedReportsWriteUpstream(t)
+
+	res := dispatchTier2(t, tier2InvokeOpts{
+		Group: "shared_reports",
+		Tool:  "clockify_create_shared_report",
+		Args: map[string]any{
+			"name":        srWriteCreateName,
+			"report_type": "SUMMARY",
+			"filter": map[string]any{
+				"exportType":     "JSON_V1",
+				"dateRangeStart": "2026-04-01T00:00:00Z",
+				"dateRangeEnd":   "2026-04-30T23:59:59Z",
+				"summaryFilter": map[string]any{
+					"groups":     []string{"PROJECT"},
+					"sortColumn": "GROUP",
+				},
+			},
+		},
+		Upstream: upstream,
+	})
+	if res.Outcome != testharness.OutcomeSuccess {
+		t.Fatalf("create outcome=%q err=%q raw=%s", res.Outcome, res.ErrorMessage, string(res.Raw))
+	}
+	if !res.UpstreamHit {
+		t.Fatalf("create did not reach upstream")
+	}
+	if !strings.Contains(res.ResultText, `"id":"`+srWriteCreatedID+`"`) {
+		t.Fatalf("create result missing created id: %q", res.ResultText)
+	}
+}
+
+func TestTier2Dispatch_SharedReports_Update(t *testing.T) {
+	upstream := newSharedReportsWriteUpstream(t)
+
+	// Pass report_type AND filter so the upstream body assertion can
+	// verify both fields end up under the renamed keys ("type" and
+	// "filter"). Without these args the previous handler's "filters"/
+	// "reportType" body keys would be silently absent and the test
+	// would pass for the wrong reason.
+	res := dispatchTier2(t, tier2InvokeOpts{
+		Group: "shared_reports",
+		Tool:  "clockify_update_shared_report",
+		Args: map[string]any{
+			"report_id":   srWriteCreatedID,
+			"name":        srWriteRenamedTo,
+			"report_type": "SUMMARY",
+			"filter": map[string]any{
+				"exportType":     "JSON_V1",
+				"dateRangeStart": "2026-04-01T00:00:00Z",
+				"dateRangeEnd":   "2026-04-30T23:59:59Z",
+			},
+		},
+		Upstream: upstream,
+	})
+	if res.Outcome != testharness.OutcomeSuccess {
+		t.Fatalf("update outcome=%q err=%q raw=%s", res.Outcome, res.ErrorMessage, string(res.Raw))
+	}
+	if !res.UpstreamHit {
+		t.Fatalf("update did not reach upstream")
+	}
+	if !strings.Contains(res.ResultText, srWriteRenamedTo) {
+		t.Fatalf("update result missing renamed name: %q", res.ResultText)
+	}
+}
+
+func TestTier2Dispatch_SharedReports_Delete(t *testing.T) {
+	upstream := newSharedReportsWriteUpstream(t)
+
+	res := dispatchTier2(t, tier2InvokeOpts{
+		Group: "shared_reports",
+		Tool:  "clockify_delete_shared_report",
+		Args: map[string]any{
+			"report_id": srWriteCreatedID,
+		},
+		Upstream: upstream,
+	})
+	if res.Outcome != testharness.OutcomeSuccess {
+		t.Fatalf("delete outcome=%q err=%q raw=%s", res.Outcome, res.ErrorMessage, string(res.Raw))
+	}
+	if !res.UpstreamHit {
+		t.Fatalf("delete did not reach upstream")
+	}
+	if !strings.Contains(res.ResultText, `"deleted":true`) {
+		t.Fatalf("delete result missing deleted flag: %q", res.ResultText)
+	}
+}
+
+func TestTier2Dispatch_SharedReports_ExportPDF(t *testing.T) {
+	upstream := newSharedReportsWriteUpstream(t)
+
+	res := dispatchTier2(t, tier2InvokeOpts{
+		Group: "shared_reports",
+		Tool:  "clockify_export_shared_report",
+		Args: map[string]any{
+			"report_id": srWriteCreatedID,
+			"format":    "pdf",
+		},
+		Upstream: upstream,
+	})
+	if res.Outcome != testharness.OutcomeSuccess {
+		t.Fatalf("export-pdf outcome=%q err=%q raw=%s", res.Outcome, res.ErrorMessage, string(res.Raw))
+	}
+	if !res.UpstreamHit {
+		t.Fatalf("export-pdf did not reach upstream")
+	}
+	if !strings.Contains(res.ResultText, `"contentType":"application/pdf"`) {
+		t.Fatalf("export-pdf missing contentType: %q", res.ResultText)
+	}
+	if !strings.Contains(res.ResultText, `"filename":"Clockify_Time_Report_Summary_11/15/2023-12/07/2023.pdf"`) {
+		t.Fatalf("export-pdf filename not URL-decoded: %q", res.ResultText)
+	}
+	expectedB64 := base64.StdEncoding.EncodeToString(fakePDF)
+	if !strings.Contains(res.ResultText, `"body":"`+expectedB64+`"`) {
+		t.Fatalf("export-pdf body not base64-encoded: want substring %q in %q", expectedB64, res.ResultText)
+	}
+	if !strings.Contains(res.ResultText, `"bytes":4`) {
+		t.Fatalf("export-pdf bytes count missing: %q", res.ResultText)
+	}
+}
+
+func TestTier2Dispatch_SharedReports_ExportJSONStaysDecoded(t *testing.T) {
+	upstream := newSharedReportsWriteUpstream(t)
+
+	res := dispatchTier2(t, tier2InvokeOpts{
+		Group: "shared_reports",
+		Tool:  "clockify_export_shared_report",
+		Args: map[string]any{
+			"report_id": srWriteCreatedID,
+			"format":    "json",
+		},
+		Upstream: upstream,
+	})
+	if res.Outcome != testharness.OutcomeSuccess {
+		t.Fatalf("export-json outcome=%q err=%q raw=%s", res.Outcome, res.ErrorMessage, string(res.Raw))
+	}
+	// JSON_V1 must NOT be base64-wrapped — it stays a structured map.
+	if strings.Contains(res.ResultText, `"body":"`) {
+		t.Fatalf("export-json must stay decoded (not wrapped in base64 envelope): %q", res.ResultText)
+	}
+	if !strings.Contains(res.ResultText, `"id":"`+srWriteCreatedID+`"`) {
+		t.Fatalf("export-json missing decoded report id: %q", res.ResultText)
 	}
 }

--- a/internal/tools/tier2_workflow_test.go
+++ b/internal/tools/tier2_workflow_test.go
@@ -105,7 +105,10 @@ func TestListApprovalRequests(t *testing.T) {
 	}
 }
 
-// TestCreateSharedReport verifies the mock POST for creating a shared report.
+// TestCreateSharedReport verifies the mock POST for creating a shared
+// report. Pins the rev-4 body conventions (lab probe 2026-05-03):
+// canonical body keys are "type" (NOT "reportType") and "filter" (NOT
+// "filters"); filter must include exportType, dateRangeStart, dateRangeEnd.
 func TestCreateSharedReport(t *testing.T) {
 	client, cleanup := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -117,13 +120,26 @@ func TestCreateSharedReport(t *testing.T) {
 			if body["name"] != "Weekly Team Report" {
 				t.Fatalf("expected name 'Weekly Team Report', got %v", body["name"])
 			}
-			if body["reportType"] != "SUMMARY" {
-				t.Fatalf("expected reportType 'SUMMARY', got %v", body["reportType"])
+			if _, has := body["reportType"]; has {
+				t.Fatalf("stale body key 'reportType' present (must be 'type'): %v", body)
+			}
+			if body["type"] != "SUMMARY" {
+				t.Fatalf("expected type 'SUMMARY', got %v", body["type"])
+			}
+			if _, has := body["filters"]; has {
+				t.Fatalf("stale body key 'filters' present (must be 'filter'): %v", body)
+			}
+			filter, ok := body["filter"].(map[string]any)
+			if !ok {
+				t.Fatalf("'filter' missing or not an object: %v", body)
+			}
+			if filter["exportType"] != "JSON_V1" {
+				t.Fatalf("expected filter.exportType=JSON_V1, got %v", filter["exportType"])
 			}
 			respondJSON(t, w, map[string]any{
-				"id":         "sr1",
-				"name":       "Weekly Team Report",
-				"reportType": "SUMMARY",
+				"id":   "sr1",
+				"name": "Weekly Team Report",
+				"type": "SUMMARY",
 			})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -135,6 +151,11 @@ func TestCreateSharedReport(t *testing.T) {
 	result, err := svc.createSharedReport(context.Background(), map[string]any{
 		"name":        "Weekly Team Report",
 		"report_type": "SUMMARY",
+		"filter": map[string]any{
+			"exportType":     "JSON_V1",
+			"dateRangeStart": "2026-04-01T00:00:00Z",
+			"dateRangeEnd":   "2026-04-30T23:59:59Z",
+		},
 	})
 	if err != nil {
 		t.Fatalf("create shared report failed: %v", err)
@@ -151,16 +172,22 @@ func TestCreateSharedReport(t *testing.T) {
 	}
 }
 
-// TestDeleteSharedReportDryRun verifies that dry_run=true does NOT call DELETE.
+// TestDeleteSharedReportDryRun verifies that dry_run=true does NOT
+// call DELETE. The dry-run preview GET hits the bare-id path
+// (/shared-reports/{id} with ?exportType=JSON_V1) — workspace-prefixed
+// GET on per-id is 405 live; see findings/shared-reports.md OQ #5.
 func TestDeleteSharedReportDryRun(t *testing.T) {
 	var deleteCalled bool
 	client, cleanup := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/workspaces/ws1/shared-reports/sr1" && r.Method == http.MethodGet:
+		case r.URL.Path == "/shared-reports/sr1" && r.Method == http.MethodGet:
+			if r.URL.Query().Get("exportType") != "JSON_V1" {
+				t.Fatalf("dry-run preview must send ?exportType=JSON_V1, got %q", r.URL.RawQuery)
+			}
 			respondJSON(t, w, map[string]any{
-				"id":         "sr1",
-				"name":       "Weekly Team Report",
-				"reportType": "SUMMARY",
+				"id":   "sr1",
+				"name": "Weekly Team Report",
+				"type": "SUMMARY",
 			})
 		case r.URL.Path == "/workspaces/ws1/shared-reports/sr1" && r.Method == http.MethodDelete:
 			deleteCalled = true


### PR DESCRIPTION
## Summary

- Fix the four `shared_reports` write/export tools — each was silently broken against live Clockify before this PR. Lab evidence (clockify-api-probe-lab, rev 4 finding) mapped every required delta on 2026-05-03; this PR lands the smallest correct change per tool plus tests that pin them.
- Adds `clockify.RawResponse` + `Client.GetReportsRaw` so the export handler can stream binary (PDF/XLSX) and text (CSV) bodies through the existing retry/tracing/metrics pipeline without trying to JSON-decode them.

## Per-tool changes

| Tool | Change | Lab evidence |
|---|---|---|
| `clockify_create_shared_report` | Body keys `reportType`→`type`, `filters`→`filter`; `filter` is now required and its schema documents `exportType`/`dateRangeStart`/`dateRangeEnd` as required nested fields. `report_type` enum widened to the 19 server-accepted values (was just SUMMARY/DETAILED/WEEKLY). | `fixtures/shared-reports/create-{1-min,2-with-filter,3-with-summaryFilter,4-correct-fieldnames}.json` |
| `clockify_update_shared_report` | Same body-key renames. **Path stays workspace-prefixed** (PUT works at `/workspaces/{ws}/shared-reports/{id}`; bare-id PUT/PATCH both 405). PUT is merge semantics — partial body preserves the existing filter. | `fixtures/shared-reports/update-{bare-put,bare-patch,wsprefixed-put}.json` |
| `clockify_delete_shared_report` | Production DELETE path unchanged (workspace-prefixed; live 204). The dry-run preview now hits the bare-id GET; the previous workspace-prefixed GET 405s live, so the preview had been silently broken. | `fixtures/shared-reports/{delete-bare,delete-wsprefixed,discover_ws-prefixed-get}.json` |
| `clockify_export_shared_report` | Drops `/export` segment (404 live); switches to bare `/shared-reports/{id}?exportType=PDF\|CSV\|XLSX\|JSON_V1`. JSON stays decoded; binary/text returns `{contentType, filename, bytes, body(base64)}` with `filename` URL-decoded from `Content-Disposition`. | `fixtures/shared-reports/{discover_ws-prefixed-export,export-pdf,export-csv,export-xlsx}.{json,headers.txt,binary-summary.json}` |

## Tests

Landed RED first then GREEN (per repo TDD rule):
- `TestTier2Dispatch_SharedReports_Create` — pins `type` (not `reportType`) + `filter` (not `filters`) + required nested fields
- `TestTier2Dispatch_SharedReports_Update` — pins workspace-prefixed PUT + body-key renames
- `TestTier2Dispatch_SharedReports_Delete` — pins workspace-prefixed DELETE + 204 tolerance
- `TestTier2Dispatch_SharedReports_ExportPDF` — pins bare-id route + base64 envelope + URL-decoded filename
- `TestTier2Dispatch_SharedReports_ExportJSONStaysDecoded` — pins JSON path stays a decoded map (not base64-wrapped)

Pre-existing tests `TestCreateSharedReport` and `TestDeleteSharedReportDryRun` flipped from pinning the old wrong behaviour to pinning the new correct behaviour.

Drift checks recorded in commit body: flipping `"type"`→`"reportType"` makes Create fail with the explicit stale-field assertion; re-introducing `/export` segment makes ExportPDF fail with the explicit trip-wire.

## Catalog regen

`docs/tool-catalog.{json,md}` regenerated; descriptors now reflect updated `report_type` enum (19 values), `filter` required on create, narrower `format` enum on export, plus the binary-aware envelope description. `make config-doc-parity` and `make catalog-drift` both pass.

## Test plan

- [x] `go test ./internal/tools/...`
- [x] `go test ./...`
- [x] `go build -tags=grpc,postgres,livee2e ./...`
- [x] `make check`
- [x] `make config-doc-parity`
- [x] `make catalog-drift`
- [x] Drift check: stale-key regression in Create handler triggers `TestTier2Dispatch_SharedReports_Create` failure
- [x] Drift check: `/export` regression triggers `TestTier2Dispatch_SharedReports_ExportPDF` trip-wire
- [ ] CI green

## Out of scope

- The dry-run wiring on other destructive Tier 2 tools (broader gap noted in `docs/api-coverage.md` — only 6 of 14 destructive tools wire `dry_run` and only 1 is live-tested).
- Live-contract evidence on the candidate SHA (Group 1 blocker — separate workstream per `AGENTS.md`).