### PR TITLE
test(livee2e): cover exhaustive Clockify tool surface

### DIFF
--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -33,11 +33,17 @@ safety classification, and test coverage. Generated from
 | **mocked integration** | `go test` with httptest mocks | Client→API path, error mapping, retry behaviour |
 | **live read-only** | `-tags=livee2e` read-only tier | Schema drift, auth flow, rate-limit behaviour |
 | **sacrificial mutating** | `-tags=livee2e` with `CLOCKIFY_LIVE_WRITE_ENABLED=true` | Full CRUD, audit phases |
+| **live-probed unsupported** | `-tags=livee2e` tool call reaches Clockify and asserts a concrete 4xx / workspace-state response | Upstream gaps, plan gates, permission gates, unsupported routes |
 | **scheduled workflow** | `.github/workflows/live-contract.yml` cron | Authoritative evidence for launch gates |
 
 ---
 
 ## Tier 1 — Core tools (33)
+
+The per-tool tables below list the stable local test coverage that
+ships with normal CI. The manual sacrificial-workspace section later
+in this document records the exhaustive live-probe layer added on top
+of these unit/mocked tests.
 
 Clockify endpoints: `GET/POST/PUT/PATCH/DELETE /workspaces/{ws}/time-entries`,
 `/workspaces/{ws}/projects`, `/workspaces/{ws}/clients`,
@@ -301,23 +307,25 @@ between those descriptors and the live Clockify API's current accepted fields.
 | Tool | Tier | dry_run in schema | Live-tested | Notes |
 |------|------|-------------------|-------------|-------|
 | `clockify_delete_entry` | 1 | via enforcement pipeline | yes (`TestLiveDryRunDoesNotMutate`) | Only Tier 1 destructive tool |
-| `clockify_delete_custom_field` | 2 | yes | no | Described as "supports dry_run preview" |
-| `clockify_delete_expense` | 2 | no | no | |
-| `clockify_delete_expense_category` | 2 | no | no | |
-| `clockify_delete_holiday` | 2 | yes | no | "supports dry_run preview" |
-| `clockify_delete_user_group_admin` | 2 | yes | no | "supports dry_run preview" |
-| `clockify_delete_invoice` | 2 | no | no | Billing |
-| `clockify_delete_invoice_item` | 2 | no | no | Billing |
-| `clockify_delete_shared_report` | 2 | no | no | |
-| `clockify_delete_assignment` | 2 | yes | no | Minimal dry-run only; Clockify has no single-assignment GET preview route |
-| `clockify_delete_time_off_request` | 2 | yes | no | "supports dry_run preview" |
-| `clockify_delete_webhook` | 2 | no | no | external_side_effect |
-| `clockify_remove_user_from_group` | 2 | no | no | Admin (destructive user op) |
-| `clockify_deactivate_user` | 2 | no | no | Admin (classified mutating, not destructive) |
+| `clockify_delete_custom_field` | 2 | yes | conditional | Live test exercises this when the workspace is below the 50 custom-field cap; cap-skip is documented |
+| `clockify_delete_expense` | 2 | yes | yes | Expense dry-run + real delete in `TestLiveT2ExpensesCRUD` |
+| `clockify_delete_expense_category` | 2 | no | yes (4xx) | Live-probed archive-before-delete constraint; API exposes no archive route |
+| `clockify_delete_holiday` | 2 | yes | yes (4xx) | Bogus-id/not-found path pinned; real created holiday cleanup uses raw client |
+| `clockify_delete_user_group_admin` | 2 | yes | yes | Dry-run + real delete in `TestLiveT2GroupsHolidaysCRUD` |
+| `clockify_delete_invoice` | 2 | yes | yes | Billing dry-run + real delete in `TestLiveT2InvoicesCRUD` |
+| `clockify_delete_invoice_item` | 2 | yes | yes | Billing line-order delete in `TestLiveT2InvoicesCRUD` |
+| `clockify_delete_shared_report` | 2 | yes | yes | Dry-run + real delete in `TestLiveT2SharedReportsCRUDAndExports` |
+| `clockify_delete_assignment` | 2 | yes | yes | Minimal dry-run; real delete on recurring-assignment route |
+| `clockify_delete_time_off_request` | 2 | yes | yes / 4xx | Real request delete when permitted; otherwise permission/route response pinned |
+| `clockify_delete_webhook` | 2 | yes | yes | Dry-run + real delete in `TestLiveT2WebhooksCRUD` |
+| `clockify_remove_user_from_group` | 2 | yes | yes | Dry-run + real remove in `TestLiveT2UserAdminCRUDAndOwnerSafety` |
+| `clockify_deactivate_user` | 2 | yes | yes (dry-run only) | Owner deactivation is never executed; dry-run envelope is pinned |
 
-**Dry-run support: 6 of 14** (43%) destructive tools have dry_run wired.
-**Dry-run live-tested: 1 of 14** (7%). The 5 Tier 2 tools with `dry_run`
-in schema have never been exercised against a live Clockify workspace.
+**Dry-run support:** destructive/admin/billing handlers now expose
+dry-run previews where the descriptor supports them. The exhaustive
+manual suite live-probes every destructive tool name; some assertions
+intentionally capture upstream 4xx constraints rather than a successful
+preview/delete pair.
 
 ### Policy-mode live test coverage
 
@@ -373,12 +381,23 @@ surface and surface latent handler / upstream bugs.
 | `TestLiveT2ProjectAdminCRUD` | `seed_project`, `create_project_template`, `get_project_template`, `update_project_estimate`, `set_project_memberships`, `archive_projects` | success path |
 | `TestLivePolicyModes` | `clockify_create_client` parametrised over all 5 policy modes (`read_only`, `time_tracking_safe`, `safe_core`, `standard`, `full`) | gate behaviour pinned |
 | `TestLivePaginationOnTags` | `clockify_list_tags` pagination meta envelope; `clockify_create_tag` (Tier 1) seeded × 11 | success path |
+| `TestLiveTier1RemainingCRUD` | remaining Tier-1 tool names not covered by the first campaign: `get_project`, `list_clients`, `list_entries`, `create_task`, `log_time`, `update_entry`, `find_and_update_entry`, `switch_project`, `stop_timer`, `search_tools` | success path |
+| `TestLiveT2InvoicesCRUD` | all 12 invoice tools: invoice create/list/get/update/delete, invoice report, item add/list/delete, send dry-run, mark-paid dry-run + real; update-item route asserted as unsupported on this Clockify version | success path + documented unsupported `PUT /items/{order}` 405 |
+| `TestLiveT2SharedReportsCRUDAndExports` | all 6 shared-report tools: SUMMARY create/get/update/export JSON/PDF/delete; DETAILED/WEEKLY JSON export when workspace fixtures exist | success path / conditional export breadth |
+| `TestLiveT2UserAdminCRUDAndOwnerSafety` | all 8 user-admin tools: user-group create/update/add/remove/delete, remove dry-run, deactivate owner dry-run, update-role unsupported route probe | success path + documented unsupported role route 405 |
+| `TestLiveT2WebhooksCRUD` | all 7 webhook tools: create/get/update/list-events/test dry-run/delete dry-run/delete using live `webhookEvent` + trigger-source body shape | success path |
+| `TestLiveT2TimeOffRemainingTools` | all 12 time-off tool names: policy/request list/get/create/update/delete/status/balance paths; request create reaches live body contract and unsupported/permission routes are asserted where Clockify rejects the operation | success path + plan/permission/unsupported-route probes |
+| `TestLiveT2ApprovalsRemainingTools` | all 6 approvals tool names: list, submit period/periodStart, get, approve/reject dry-run, withdraw | success path + documented approval period / GET-route 4xx probes |
 
-**Live-tested tools (campaign expansion):** ~25 of 33 Tier 1 tools
-(76%) and ~40 of 88 Tier 2 tools (45%) are now exercised through the
-MCP path against the sacrificial workspace. Remaining pinned coverage
-is limited to documented upstream constraints such as expense-category
-archive-before-delete and workspace-state caps.
+**Live-probed tool coverage (manual campaign expansion):** all 121
+catalog tools (33 Tier 1 + 88 Tier 2) are now named in `tests/e2e_live*.go`
+and exercised through the MCP path against the sacrificial workspace.
+That does **not** mean every tool has a live success path: the tests
+distinguish successful CRUD from concrete upstream constraints such as
+expense-category archive-before-delete, custom-field workspace caps,
+invoice-item update 405, user-role update 405, time-off permission /
+unsupported routes, and approval-period or approval GET-route 4xx
+responses.
 
 ### API contract fixes closed by the campaign (May 2026)
 
@@ -405,6 +424,27 @@ upstream limitation:
 9. Project memberships use PATCH replace semantics and return the
    updated memberships from the full project object.
 10. Custom-field descriptors advertise the live enum values.
+11. Invoice create/update carry live-required `number` and RFC3339
+    `issuedDate`; mark-paid carries forward the required invoice
+    fields before setting `status=PAID`; invoice items use
+    workspace item type names, `applyTaxes`, and line-order path
+    parameters. `update_invoice_item` is live-pinned as unsupported
+    (`PUT /items/{order}` returns 405 on this Clockify version).
+12. Expense update now fetches and carries forward live-required
+    multipart fields (`userId`, `date`, `amount`, `categoryId`,
+    `billable`) before applying the requested `change_fields`.
+13. Webhook create/update use the live `webhookEvent`,
+    `triggerSourceType`, and `triggerSource` body shape rather than
+    the old plural `events` array. Webhook names are constrained to
+    2-30 characters.
+14. Time-off request create uses nested `timeOffPeriod.period` with
+    `start`, `end`, and computed inclusive `days`; request status
+    changes use `PATCH /time-off/policies/{policyId}/requests/{id}`
+    with `status=APPROVED|REJECTED`.
+15. Approval submit uses the documented `period` + `periodStart`
+    body. The sacrificial workspace currently returns
+    "Approval period has changed..." for the probed weekly submit,
+    and per-id approval GET is pinned as 405 unsupported.
 
 ### Workspace-state findings
 
@@ -422,19 +462,22 @@ upstream limitation:
 
 ## Gaps
 
-1. **Tier 2 live coverage (success path):** ~40 of 88 Tier 2 tools
-   are now exercised through the MCP path. Remaining gaps are mostly
-   surfaces with external side effects, workspace-state caps, or
-   premium/admin semantics that need separate blast-radius review.
+1. **Full-success live coverage:** all 121 catalog tools are
+   live-probed through MCP, but some remain asserted as upstream
+   unsupported, permission-gated, plan-gated, or workspace-state
+   limited rather than full success paths.
 2. **Schema-drift for mutating endpoints:** Only read-side schemas are
    drift-checked. Request payload schemas (tool JSON Schema descriptors)
    are not automatically compared against the live API's accepted fields.
-3. **Dry-run exhaustiveness:** 6 of 14 destructive tools have `dry_run` wired;
-   only 1 (`clockify_delete_entry`) is live-tested. See Dry-run/policy section
-   above for the full per-tool breakdown.
-4. **Policy exhaustiveness:** 2 of 5 policy modes are live-tested
-   (`standard` implicitly via `TestE2EMutating`, `time_tracking_safe`
-   explicitly). See Policy-mode table above for per-mode status.
+3. **Scheduled evidence breadth:** the exhaustive tool probes are
+   manual/local artefacts. The scheduled cron intentionally keeps a
+   narrower `-run` regex until the maintainer separately approves
+   nightly blast radius for admin/billing/webhook/time-off/approval
+   side effects.
+4. **Dry-run semantics:** destructive dry-run is broader than before,
+   but not every destructive tool exposes a dry-run preview route.
+   Several tools rely on minimal dry-run envelopes or upstream 4xx
+   constraints because Clockify lacks a safe preview endpoint.
 5. **Rate-limit behaviour:** No automated tests exercise Clockify's rate
    limiter or the MCP server's retry/backoff behaviour under live load.
 6. **Pagination consistency:** `clockify_list_entries`, `clockify_list_projects`,
@@ -443,23 +486,23 @@ upstream limitation:
 
 ## Recommended next tests (safe, in priority order)
 
-1. Read-only live tests for the remaining 16 Tier 1 read-only tools
-   (4 of 20 are covered by `TestE2EReadOnly`)
-2. Read-only live tests for high-value Tier 2 read-only tools
-   (e.g., `clockify_list_custom_fields`, `clockify_list_webhooks`)
-3. Schema-drift test extension to mutating endpoint request schemas
-4. Dry-run exhaustiveness sweep across all 14 destructive tools
+1. Promote only the low-blast-radius portions of the exhaustive manual
+   suite into `live-contract.yml` after separate cron review.
+2. Schema-drift test extension to mutating endpoint request schemas.
+3. Dedicated pagination boundary tests for the list endpoints whose
+   page/page-size behaviour is still only unit-covered.
+4. Optional rate-limit / retry-behaviour probe against a disposable
+   workspace with explicit operator approval.
 
-## Known unresolved API contract questions
+## Known API contract notes
 
 Probe-lab evidence (`clockify-api-probe-lab/findings/`) raised a small
-number of numeric / shape questions that were not resolved before the
-PRs in the recent contract-fix wave (#53–#56) merged. The handlers
-currently pass through whatever the upstream returns; these notes
-record what would have to be probed before any conversion or
-auto-validation could be added safely.
+number of numeric / shape questions during the live campaign. The
+handlers intentionally pass through upstream money values as raw API
+numbers; no cents-to-decimal or decimal-to-cents conversion is applied
+inside go-clockify.
 
-### invoice line-item amounts (unresolved)
+### invoice line-item amounts (raw minor units)
 
 - **Source:** `clockify-api-probe-lab/findings/invoices.md` lines
   77–95 and the open-questions section.
@@ -470,18 +513,14 @@ auto-validation could be added safely.
   integer minor units (cents). The list-invoice envelope's top-level
   `amount`, `paid`, `balance` fields use the same `<integer cents>`
   notation in the probe write-up.
-- **Status in go-clockify:** `clockify_get_invoice` and
-  `clockify_list_invoices` (and `clockify_list_invoice_items`, which
-  PR #53 repointed to the embedded array) all surface the upstream
-  numbers verbatim. No conversion is performed and no schema
-  documentation in the descriptors states a unit.
-- **Open question (low priority):** is `unitPrice` always integer
-  minor units, or is the unit currency-dependent? Until that is
-  proved against multiple workspace currencies, the tool output
-  must be treated by callers as raw upstream values, not as a
-  pre-converted decimal amount.
+- **Status in go-clockify:** `clockify_get_invoice`,
+  `clockify_list_invoices`, `clockify_list_invoice_items`,
+  `clockify_add_invoice_item`, and `clockify_update_invoice_item`
+  surface/send these numbers verbatim. The descriptors now call this
+  out as a raw upstream value; the live API uses minor units/cents for
+  invoice item `unitPrice`.
 
-### expense `amount` vs `total` scaling (unresolved)
+### expense `amount` vs `total` scaling (raw pass-through)
 
 - **Source:** `clockify-api-probe-lab/findings/expenses.md`
   lines 155–161 and open-question #1.
@@ -492,14 +531,13 @@ auto-validation could be added safely.
   units (×100 scaling); (b) `amount` is a multiplier against a
   workspace default rate. The probe could not distinguish these
   without more workspaces.
-- **Status in go-clockify:** `clockify_create_expense` (fixed in
-  PR #53 to use multipart) accepts whatever the caller passes for
-  `amount`; `clockify_list_expenses` and `clockify_get_expense`
-  return the upstream `total` verbatim.
-- **Open question (low priority):** confirm direction and rate
-  before exposing either number as a "decimal amount" in the tool
-  schema. Until then, the descriptor must keep `amount` documented
-  as "the value the API expects, no client-side scaling".
+- **Status in go-clockify:** `clockify_create_expense` accepts
+  whatever the caller passes for `amount`; `clockify_update_expense`
+  carries the existing required amount forward unless the caller
+  explicitly changes it; `clockify_list_expenses` and
+  `clockify_get_expense` return upstream totals verbatim. The
+  descriptor now describes `amount` as a raw upstream value with no
+  client-side scaling.
 
 ### expense `projectId` optional-vs-required (unresolved)
 
@@ -575,4 +613,4 @@ committed into go-clockify.
 
 ---
 
-*Tool names and classification counts verified against `docs/tool-catalog.json` on 2026-05-02. Re-run verification after `make gen-tool-catalog`.*
+*Tool names and classification counts verified against `docs/tool-catalog.json` on 2026-05-03. Re-run verification after `make gen-tool-catalog`.*

--- a/docs/live-campaign-next.md
+++ b/docs/live-campaign-next.md
@@ -9,7 +9,7 @@ This doc tells the next agent (or maintainer) exactly what state the
 live-validation campaign is in, what tests pass, what bugs were
 surfaced, what's left to do, and how to re-run everything locally.
 
-## Status update — 2026-05-03 (post-PR #53–#56)
+## Status update — 2026-05-03 (post-PR #53–#58 and exhaustive follow-up)
 
 The bulk of the bug inventory below was closed across four merged
 PRs (#53–#56) and one cleanup branch removing the matching phantom
@@ -54,17 +54,30 @@ schedule tools. The status, item-by-item against the numbered list:
 Not changed: the binding rules in this doc (manual livee2e is **not**
 launch evidence; live-contract.yml stays untouched; nothing here
 ticks Group 1/6/7 boxes on the launch-candidate checklist). Unresolved
-**numeric / unit questions** (invoice `unitPrice` cents, expense
-`amount`/`total` scaling, expense `projectId` optional-vs-required,
-shared-reports non-`SUMMARY` filter requirements) are now documented
-in `docs/api-coverage.md` under "Known unresolved API contract
-questions" rather than tracked here.
+**numeric / unit questions** (invoice `unitPrice` raw minor units,
+expense raw amount/total pass-through, expense `projectId`
+optional-vs-required, shared-reports non-`SUMMARY` filter
+requirements) are now documented in `docs/api-coverage.md` under
+"Known API contract notes" rather than tracked here.
 
 The "Bug inventory" and "Remaining work" sections below are
 preserved verbatim as the historical campaign artifact. Treat them
 as a record of what got found, not as a current task list — the
 task list is in `docs/launch-candidate-checklist.md` and
 `docs/api-coverage.md`.
+
+Follow-up branch `test/exhaustive-live-coverage-followup` extends the
+manual sacrificial-workspace suite so every one of the 121 generated
+catalog tools is named in `tests/e2e_live*.go` and exercised through
+the MCP path. New coverage includes the remaining Tier-1 CRUD/logging
+tools, full invoice CRUD/report/item probes, shared-report
+create/update/export/delete, user-admin group operations with owner
+safety dry-runs, webhook CRUD using the live `webhookEvent` body
+shape, time-off request/policy/balance probes, and approvals
+period-submit/get/status probes. Some of these are deliberately
+asserted as upstream 4xx / permission / unsupported-route outcomes
+rather than success paths; see `docs/api-coverage.md` for the current
+evidence table.
 
 ## Branch state
 
@@ -113,6 +126,12 @@ All gated by `//go:build livee2e` and live in `tests/`:
 | `tests/e2e_live_t2_project_admin_test.go` | `TestLiveT2ProjectAdminCRUD` | 6 | template / estimate / memberships / archive |
 | `tests/e2e_live_policy_modes_test.go` | `TestLivePolicyModes` | 5 | parametric `create_client` per policy mode |
 | `tests/e2e_live_pagination_test.go` | `TestLivePaginationOnTags` | 3 | seed 11 tags + pagination meta + walk |
+| `tests/e2e_live_tier1_remaining_crud_test.go` | `TestLiveTier1RemainingCRUD` | 1 flow | remaining Tier-1 CRUD/log/search coverage |
+| `tests/e2e_live_t2_invoices_test.go` | `TestLiveT2InvoicesCRUD` | 1 flow | all invoice tools; update item pinned as unsupported 405 |
+| `tests/e2e_live_t2_shared_reports_test.go` | `TestLiveT2SharedReportsCRUDAndExports` | 1 flow | SUMMARY CRUD/export plus conditional DETAILED/WEEKLY export |
+| `tests/e2e_live_t2_user_admin_test.go` | `TestLiveT2UserAdminCRUDAndOwnerSafety` | 1 flow | user-admin group CRUD, membership add/remove, owner dry-run safety |
+| `tests/e2e_live_t2_webhooks_test.go` | `TestLiveT2WebhooksCRUD` | 1 flow | webhook CRUD using live singular-event contract |
+| `tests/e2e_live_t2_time_off_approvals_test.go` | `TestLiveT2TimeOffRemainingTools`, `TestLiveT2ApprovalsRemainingTools` | 2 | time-off and approvals probes with success and concrete 4xx outcomes |
 
 ## Historical bug inventory (13 findings, now closed or documented)
 
@@ -226,7 +245,7 @@ After the post-campaign sweep:
 ### Closed handler work
 
 The numbered handler bugs above are no longer pending. Current live
-coverage gaps, unresolved numeric-unit questions, and upstream
+coverage gaps, raw numeric-unit notes, and upstream
 workspace-state limitations are tracked in `docs/api-coverage.md`.
 
 ### Workspace state work (no code change required)
@@ -238,24 +257,27 @@ workspace-state limitations are tracked in `docs/api-coverage.md`.
    Clockify UI (archive in UI → DELETE accepted). Names are listed
    above.
 
-### Future test additions (not blockers, just gaps)
+### Exhaustive follow-up coverage (landed after the historical campaign)
 
-10. Live tests for the 8 remaining Tier-1 tools that still lack
-    coverage: `clockify_log_time`, `clockify_update_entry`,
-    `clockify_find_and_update_entry`, `clockify_switch_project`,
-    `clockify_create_task`, plus the rest. Each is a small
-    additive test mirroring the existing patterns.
-11. Approvals CRUD test (Phase 11 was skipped). Requires a
-    timesheet to operate on. Sends external email even on the
-    sacrificial workspace; should gate behind a future
-    external-side-effects env var (see reserved gate names below).
-12. Webhook CRUD (Phase 13 was skipped). Even though
-    `list_webhooks` is broken, `create_webhook` against
-    `https://example.com/...` may work if URL validation passes.
-    The campaign safety rule prefers to skip this since we don't
-    control the destination.
-13. Time-off policy + request CRUD (Phase 10 was skipped). Same
-    email-side-effect reasoning.
+10. Remaining Tier-1 CRUD/logging/search tools are covered by
+    `TestLiveTier1RemainingCRUD`.
+11. Invoice CRUD, invoice items, send dry-run, mark-paid dry-run and
+    real mark-paid, and invoice reports are covered by
+    `TestLiveT2InvoicesCRUD`.
+12. Shared-report SUMMARY create/update/export/delete and conditional
+    DETAILED/WEEKLY export probes are covered by
+    `TestLiveT2SharedReportsCRUDAndExports`.
+13. User-admin user-group CRUD, membership add/remove, owner
+    deactivate dry-run, and update-role unsupported-route evidence
+    are covered by `TestLiveT2UserAdminCRUDAndOwnerSafety`.
+14. Webhook CRUD is covered by `TestLiveT2WebhooksCRUD`; the handler
+    now uses `webhookEvent`, `triggerSourceType`, and `triggerSource`
+    instead of the old plural `events` array.
+15. Time-off policy/request/balance/status tools and approvals tools
+    are covered by `TestLiveT2TimeOffRemainingTools` and
+    `TestLiveT2ApprovalsRemainingTools`, with permission and
+    unsupported-route responses pinned where the sacrificial
+    workspace rejects the operation.
 
 ### Workflow integration (separate review)
 
@@ -292,13 +314,11 @@ CLOCKIFY_LIVE_BILLING_ENABLED=true
 CLOCKIFY_LIVE_SETTINGS_ENABLED=true
 ```
 
-Reserved gate names for deferred phases (defined in the original
-campaign plan, present in the env file, but not yet read by any test
-because their phases were intentionally skipped — see "Future test
-additions" above): a webhook-registration gate (Phase 13 — webhooks)
-and an external-side-effects gate (Phases 10/11 — time_off and
-approvals which trigger email). When those phases land, the tests
-will start gating on them and they should be added to this list.
+The original campaign reserved separate webhook-registration and
+external-side-effect gate names for deferred phases. The exhaustive
+follow-up instead uses the existing explicit full-surface/admin/billing
+gates plus `CLOCKIFY_LIVE_WORKSPACE_CONFIRM`; keep any future cron
+promotion behind a separate blast-radius review.
 
 The `CLOCKIFY_LIVE_WORKSPACE_CONFIRM` second-factor check is a
 deliberate defense against a misconfigured shell mutating a wrong

--- a/docs/tool-catalog.json
+++ b/docs/tool-catalog.json
@@ -4102,7 +4102,7 @@
     },
     {
       "name": "clockify_submit_for_approval",
-      "description": "Submit a timesheet for approval with a date range",
+      "description": "Submit a timesheet for approval for a configured approval period",
       "group": "approvals",
       "tier": 2,
       "read_only": false,
@@ -4114,18 +4114,24 @@
       "input_schema": {
         "additionalProperties": false,
         "properties": {
-          "end": {
-            "description": "End date (YYYY-MM-DD or RFC3339)",
+          "period": {
+            "description": "Approval period; must match workspace approval settings",
+            "enum": [
+              "WEEKLY",
+              "SEMI_MONTHLY",
+              "MONTHLY"
+            ],
             "type": "string"
           },
-          "start": {
-            "description": "Start date (YYYY-MM-DD or RFC3339)",
+          "period_start": {
+            "description": "Period start in RFC3339/millisecond form, e.g. 2026-05-01T00:00:00.000Z",
+            "format": "date-time",
             "type": "string"
           }
         },
         "required": [
-          "start",
-          "end"
+          "period",
+          "period_start"
         ],
         "type": "object"
       },
@@ -4556,7 +4562,7 @@
         "additionalProperties": false,
         "properties": {
           "amount": {
-            "description": "Expense amount (major currency units)",
+            "description": "Raw upstream expense amount value; no client-side currency scaling is applied",
             "type": "number"
           },
           "billable": {
@@ -5535,6 +5541,7 @@
       ],
       "audit_keys": [
         "invoice_id",
+        "item_type",
         "description",
         "quantity",
         "unit_price"
@@ -5542,21 +5549,37 @@
       "input_schema": {
         "additionalProperties": false,
         "properties": {
+          "apply_taxes": {
+            "description": "Tax application enum; defaults to NONE",
+            "enum": [
+              "TAX1",
+              "TAX2",
+              "TAX1TAX2",
+              "NONE"
+            ],
+            "type": "string"
+          },
           "description": {
             "type": "string"
           },
           "invoice_id": {
             "type": "string"
           },
+          "item_type": {
+            "description": "Workspace invoice item type name (required by live API; e.g. NEW DEFAULT in the sacrificial workspace)",
+            "type": "string"
+          },
           "quantity": {
             "type": "number"
           },
           "unit_price": {
+            "description": "Raw upstream unit price value; live API uses minor units/cents",
             "type": "number"
           }
         },
         "required": [
-          "invoice_id"
+          "invoice_id",
+          "item_type"
         ],
         "type": "object"
       },
@@ -5598,6 +5621,8 @@
       ],
       "audit_keys": [
         "client_id",
+        "number",
+        "issued_date",
         "currency",
         "due_date"
       ],
@@ -5613,16 +5638,27 @@
             "type": "string"
           },
           "due_date": {
-            "description": "Due date (YYYY-MM-DD)",
+            "description": "Due date (RFC3339 yyyy-MM-ddThh:mm:ssZ)",
+            "type": "string"
+          },
+          "issued_date": {
+            "description": "Issued date (RFC3339 yyyy-MM-ddThh:mm:ssZ)",
             "type": "string"
           },
           "note": {
             "description": "Invoice note",
             "type": "string"
+          },
+          "number": {
+            "description": "Invoice number (required by live API)",
+            "type": "string"
           }
         },
         "required": [
-          "client_id"
+          "client_id",
+          "number",
+          "issued_date",
+          "due_date"
         ],
         "type": "object"
       },
@@ -5730,6 +5766,7 @@
             "type": "string"
           },
           "item_id": {
+            "description": "Invoice line order (live API path parameter), not a Mongo-style id",
             "type": "string"
           }
         },
@@ -6106,12 +6143,20 @@
             "type": "string"
           },
           "due_date": {
+            "description": "Due date (RFC3339 yyyy-MM-ddThh:mm:ssZ)",
             "type": "string"
           },
           "invoice_id": {
             "type": "string"
           },
+          "issued_date": {
+            "description": "Issued date (RFC3339 yyyy-MM-ddThh:mm:ssZ)",
+            "type": "string"
+          },
           "note": {
+            "type": "string"
+          },
+          "number": {
             "type": "string"
           },
           "status": {
@@ -6163,6 +6208,7 @@
       "audit_keys": [
         "invoice_id",
         "item_id",
+        "item_type",
         "description",
         "quantity",
         "unit_price"
@@ -6170,6 +6216,16 @@
       "input_schema": {
         "additionalProperties": false,
         "properties": {
+          "apply_taxes": {
+            "description": "Tax application enum; defaults to NONE",
+            "enum": [
+              "TAX1",
+              "TAX2",
+              "TAX1TAX2",
+              "NONE"
+            ],
+            "type": "string"
+          },
           "description": {
             "type": "string"
           },
@@ -6177,18 +6233,25 @@
             "type": "string"
           },
           "item_id": {
+            "description": "Invoice line order (live API path parameter), not a Mongo-style id",
+            "type": "string"
+          },
+          "item_type": {
+            "description": "Workspace invoice item type name (required by live API)",
             "type": "string"
           },
           "quantity": {
             "type": "number"
           },
           "unit_price": {
+            "description": "Raw upstream unit price value; live API uses minor units/cents",
             "type": "number"
           }
         },
         "required": [
           "invoice_id",
-          "item_id"
+          "item_id",
+          "item_type"
         ],
         "type": "object"
       },
@@ -7574,7 +7637,7 @@
             "type": "boolean"
           },
           "note": {
-            "description": "Optional note/reason",
+            "description": "Required note/reason",
             "type": "string"
           },
           "policy_id": {
@@ -7588,7 +7651,8 @@
         "required": [
           "policy_id",
           "start",
-          "end"
+          "end",
+          "note"
         ],
         "type": "object"
       },
@@ -8066,12 +8130,6 @@
       "input_schema": {
         "additionalProperties": false,
         "properties": {
-          "end": {
-            "type": "string"
-          },
-          "half_day": {
-            "type": "boolean"
-          },
           "note": {
             "type": "string"
           },
@@ -8081,7 +8139,12 @@
           "request_id": {
             "type": "string"
           },
-          "start": {
+          "status": {
+            "description": "Status to set via Clockify's PATCH route",
+            "enum": [
+              "APPROVED",
+              "REJECTED"
+            ],
             "type": "string"
           }
         },
@@ -8587,31 +8650,52 @@
         "external_side_effect"
       ],
       "audit_keys": [
+        "name",
         "url",
-        "events"
+        "webhook_event",
+        "trigger_source_type",
+        "trigger_source"
       ],
       "input_schema": {
         "additionalProperties": false,
         "properties": {
-          "events": {
-            "description": "List of event types to subscribe to",
+          "name": {
+            "description": "Webhook name (required by live API)",
+            "type": "string"
+          },
+          "trigger_source": {
+            "description": "Trigger source IDs (default: current workspace ID)",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
-          "name": {
-            "description": "Optional name for the webhook",
+          "trigger_source_type": {
+            "description": "Trigger source type (default WORKSPACE_ID)",
+            "enum": [
+              "PROJECT_ID",
+              "USER_ID",
+              "TAG_ID",
+              "TASK_ID",
+              "WORKSPACE_ID",
+              "ASSIGNMENT_ID",
+              "EXPENSE_ID"
+            ],
             "type": "string"
           },
           "url": {
             "description": "HTTPS callback URL for webhook delivery",
             "type": "string"
+          },
+          "webhook_event": {
+            "description": "Single Clockify webhook event type, e.g. NEW_TIME_ENTRY",
+            "type": "string"
           }
         },
         "required": [
+          "name",
           "url",
-          "events"
+          "webhook_event"
         ],
         "type": "object"
       },
@@ -8904,25 +8988,45 @@
       ],
       "audit_keys": [
         "webhook_id",
+        "name",
         "url",
-        "events"
+        "webhook_event",
+        "trigger_source_type",
+        "trigger_source"
       ],
       "input_schema": {
         "additionalProperties": false,
         "properties": {
-          "events": {
-            "description": "New list of event types",
+          "name": {
+            "description": "New name for the webhook",
+            "type": "string"
+          },
+          "trigger_source": {
+            "description": "Trigger source IDs",
             "items": {
               "type": "string"
             },
             "type": "array"
           },
-          "name": {
-            "description": "New name for the webhook",
+          "trigger_source_type": {
+            "description": "Trigger source type",
+            "enum": [
+              "PROJECT_ID",
+              "USER_ID",
+              "TAG_ID",
+              "TASK_ID",
+              "WORKSPACE_ID",
+              "ASSIGNMENT_ID",
+              "EXPENSE_ID"
+            ],
             "type": "string"
           },
           "url": {
             "description": "New HTTPS callback URL",
+            "type": "string"
+          },
+          "webhook_event": {
+            "description": "Single Clockify webhook event type",
             "type": "string"
           },
           "webhook_id": {

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -54,7 +54,7 @@ re-run `make gen-tool-catalog` after changing any tool descriptor.
 | `clockify_get_approval_request` | yes | no | yes | `read` | Get a single approval request by ID |
 | `clockify_list_approval_requests` | yes | no | yes | `read` | List approval requests with optional status filter and pagination |
 | `clockify_reject_timesheet` | no | no | no | `write` | Reject a pending timesheet approval request |
-| `clockify_submit_for_approval` | no | no | no | `write` | Submit a timesheet for approval with a date range |
+| `clockify_submit_for_approval` | no | no | no | `write` | Submit a timesheet for approval for a configured approval period |
 | `clockify_withdraw_approval` | no | no | no | `write` | Withdraw a previously submitted approval request |
 
 ### `custom_fields`
@@ -199,11 +199,11 @@ default `*_id` capture in audit events. See
 
 | Tool | Tier | Audit Keys |
 |------|------|------------|
-| `clockify_add_invoice_item` | 2 | `invoice_id`, `description`, `quantity`, `unit_price` |
+| `clockify_add_invoice_item` | 2 | `invoice_id`, `item_type`, `description`, `quantity`, `unit_price` |
 | `clockify_add_user_to_group` | 2 | `group_id`, `user_id` |
-| `clockify_create_invoice` | 2 | `client_id`, `currency`, `due_date` |
+| `clockify_create_invoice` | 2 | `client_id`, `number`, `issued_date`, `currency`, `due_date` |
 | `clockify_create_user_group` | 2 | `name` |
-| `clockify_create_webhook` | 2 | `url`, `events` |
+| `clockify_create_webhook` | 2 | `name`, `url`, `webhook_event`, `trigger_source_type`, `trigger_source` |
 | `clockify_deactivate_user` | 2 | `user_id` |
 | `clockify_delete_invoice` | 2 | `invoice_id` |
 | `clockify_delete_invoice_item` | 2 | `invoice_id`, `item_id` |
@@ -214,7 +214,7 @@ default `*_id` capture in audit events. See
 | `clockify_send_invoice` | 2 | `invoice_id` |
 | `clockify_test_webhook` | 2 | `webhook_id` |
 | `clockify_update_invoice` | 2 | `invoice_id`, `status`, `client_id` |
-| `clockify_update_invoice_item` | 2 | `invoice_id`, `item_id`, `description`, `quantity`, `unit_price` |
+| `clockify_update_invoice_item` | 2 | `invoice_id`, `item_id`, `item_type`, `description`, `quantity`, `unit_price` |
 | `clockify_update_user_group` | 2 | `group_id`, `name` |
 | `clockify_update_user_role` | 2 | `user_id`, `role` |
-| `clockify_update_webhook` | 2 | `webhook_id`, `url`, `events` |
+| `clockify_update_webhook` | 2 | `webhook_id`, `name`, `url`, `webhook_event`, `trigger_source_type`, `trigger_source` |

--- a/internal/tools/risk_class_test.go
+++ b/internal/tools/risk_class_test.go
@@ -53,7 +53,7 @@ func TestRiskOverridesMatchTaxonomy(t *testing.T) {
 		"clockify_send_invoice":      {"invoice_id"},
 		"clockify_mark_invoice_paid": {"invoice_id"},
 		"clockify_update_user_role":  {"user_id", "role"},
-		"clockify_add_invoice_item":  {"invoice_id", "description", "quantity", "unit_price"},
+		"clockify_add_invoice_item":  {"invoice_id", "item_type", "description", "quantity", "unit_price"},
 		"clockify_test_webhook":      {"webhook_id"},
 	}
 

--- a/internal/tools/risk_overrides.go
+++ b/internal/tools/risk_overrides.go
@@ -28,7 +28,7 @@ var riskOverrides = map[string]riskOverride{
 	},
 	"clockify_create_invoice": {
 		class:     mcp.RiskWrite | mcp.RiskBilling,
-		auditKeys: []string{"client_id", "currency", "due_date"},
+		auditKeys: []string{"client_id", "number", "issued_date", "currency", "due_date"},
 	},
 	"clockify_update_invoice": {
 		class:     mcp.RiskWrite | mcp.RiskBilling,
@@ -40,11 +40,11 @@ var riskOverrides = map[string]riskOverride{
 	},
 	"clockify_add_invoice_item": {
 		class:     mcp.RiskWrite | mcp.RiskBilling,
-		auditKeys: []string{"invoice_id", "description", "quantity", "unit_price"},
+		auditKeys: []string{"invoice_id", "item_type", "description", "quantity", "unit_price"},
 	},
 	"clockify_update_invoice_item": {
 		class:     mcp.RiskWrite | mcp.RiskBilling,
-		auditKeys: []string{"invoice_id", "item_id", "description", "quantity", "unit_price"},
+		auditKeys: []string{"invoice_id", "item_id", "item_type", "description", "quantity", "unit_price"},
 	},
 	"clockify_delete_invoice_item": {
 		class:     mcp.RiskDestructive | mcp.RiskBilling,
@@ -98,11 +98,11 @@ var riskOverrides = map[string]riskOverride{
 	// Webhooks — external side effects.
 	"clockify_create_webhook": {
 		class:     mcp.RiskWrite | mcp.RiskExternalSideEffect,
-		auditKeys: []string{"url", "events"},
+		auditKeys: []string{"name", "url", "webhook_event", "trigger_source_type", "trigger_source"},
 	},
 	"clockify_update_webhook": {
 		class:     mcp.RiskWrite | mcp.RiskExternalSideEffect,
-		auditKeys: []string{"webhook_id", "url", "events"},
+		auditKeys: []string{"webhook_id", "name", "url", "webhook_event", "trigger_source_type", "trigger_source"},
 	},
 	"clockify_delete_webhook": {
 		class:     mcp.RiskDestructive | mcp.RiskExternalSideEffect,

--- a/internal/tools/tier2_approvals.go
+++ b/internal/tools/tier2_approvals.go
@@ -51,12 +51,16 @@ func approvalHandlers(s *Service) []mcp.ToolDescriptor {
 		}},
 
 		// 3. Submit for approval (RW)
-		{Tool: toolRW("clockify_submit_for_approval", "Submit a timesheet for approval with a date range", map[string]any{
+		{Tool: toolRW("clockify_submit_for_approval", "Submit a timesheet for approval for a configured approval period", map[string]any{
 			"type":     "object",
-			"required": []string{"start", "end"},
+			"required": []string{"period", "period_start"},
 			"properties": map[string]any{
-				"start": map[string]any{"type": "string", "description": "Start date (YYYY-MM-DD or RFC3339)"},
-				"end":   map[string]any{"type": "string", "description": "End date (YYYY-MM-DD or RFC3339)"},
+				"period": map[string]any{
+					"type":        "string",
+					"description": "Approval period; must match workspace approval settings",
+					"enum":        []string{"WEEKLY", "SEMI_MONTHLY", "MONTHLY"},
+				},
+				"period_start": map[string]any{"type": "string", "description": "Period start in RFC3339/millisecond form, e.g. 2026-05-01T00:00:00.000Z"},
 			},
 		}), ReadOnlyHint: false, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.submitForApproval(ctx, args)
@@ -157,10 +161,18 @@ func (s *Service) getApprovalRequest(ctx context.Context, args map[string]any) (
 }
 
 func (s *Service) submitForApproval(ctx context.Context, args map[string]any) (ResultEnvelope, error) {
-	startDate := stringArg(args, "start")
-	endDate := stringArg(args, "end")
-	if startDate == "" || endDate == "" {
-		return ResultEnvelope{}, fmt.Errorf("start and end are required")
+	period := stringArg(args, "period")
+	periodStart := stringArg(args, "period_start")
+	if period == "" || periodStart == "" {
+		// Backwards-compatible direct-handler fallback for pre-live-test
+		// callers. The live API accepts period/periodStart, not start/end.
+		if legacyStart := stringArg(args, "start"); legacyStart != "" {
+			period = "WEEKLY"
+			periodStart = legacyStart
+		}
+	}
+	if period == "" || periodStart == "" {
+		return ResultEnvelope{}, fmt.Errorf("period and period_start are required")
 	}
 	wsID, err := s.ResolveWorkspaceID(ctx)
 	if err != nil {
@@ -168,15 +180,15 @@ func (s *Service) submitForApproval(ctx context.Context, args map[string]any) (R
 	}
 
 	body := map[string]any{
-		"start": startDate,
-		"end":   endDate,
+		"period":      period,
+		"periodStart": periodStart,
 	}
 
 	path, err := paths.Workspace(wsID, "approval-requests")
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
-	var created map[string]any
+	var created any
 	if err := s.Client.Post(ctx, path, body, &created); err != nil {
 		return ResultEnvelope{}, err
 	}

--- a/internal/tools/tier2_approvals_dispatch_test.go
+++ b/internal/tools/tier2_approvals_dispatch_test.go
@@ -118,8 +118,8 @@ func TestTier2Dispatch_Approvals_SubmitForApproval(t *testing.T) {
 		Group: "approvals",
 		Tool:  "clockify_submit_for_approval",
 		Args: map[string]any{
-			"start": "2026-04-01T00:00:00Z",
-			"end":   "2026-04-07T23:59:59Z",
+			"period":       "WEEKLY",
+			"period_start": "2026-04-01T00:00:00.000Z",
 		},
 		Upstream: upstream,
 	})

--- a/internal/tools/tier2_expenses.go
+++ b/internal/tools/tier2_expenses.go
@@ -61,7 +61,7 @@ func expenseHandlers(s *Service) []mcp.ToolDescriptor {
 			"type":     "object",
 			"required": []string{"amount", "date", "category_id"},
 			"properties": map[string]any{
-				"amount":      map[string]any{"type": "number", "description": "Expense amount (major currency units)"},
+				"amount":      map[string]any{"type": "number", "description": "Raw upstream expense amount value; no client-side currency scaling is applied"},
 				"date":        map[string]any{"type": "string", "description": "Expense date (RFC3339 yyyy-MM-ddThh:mm:ssZ)"},
 				"category_id": map[string]any{"type": "string", "description": "Expense category ID (required)"},
 				"user_id":     map[string]any{"type": "string", "description": "User the expense is logged against; defaults to the calling user"},
@@ -306,6 +306,15 @@ func (s *Service) updateExpense(ctx context.Context, args map[string]any) (Resul
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
+	path, err := paths.Workspace(wsID, "expenses", expenseID)
+	if err != nil {
+		return ResultEnvelope{}, err
+	}
+
+	var existing map[string]any
+	if err := s.Client.Get(ctx, path, nil, &existing); err != nil {
+		return ResultEnvelope{}, err
+	}
 
 	// changeFields is mandatory and case-sensitive — without it the
 	// upstream silently ignores every other field per probe finding
@@ -328,11 +337,17 @@ func (s *Service) updateExpense(ctx context.Context, args map[string]any) (Resul
 	}
 	if v, ok := args["amount"].(float64); ok {
 		form.Set("amount", strconv.FormatFloat(v, 'f', -1, 64))
+	} else if v, ok := existing["amount"].(float64); ok {
+		form.Set("amount", strconv.FormatFloat(v, 'f', -1, 64))
 	}
 	if v := stringArg(args, "date"); v != "" {
 		form.Set("date", v)
+	} else if v, _ := existing["date"].(string); v != "" {
+		form.Set("date", v)
 	}
 	if v := stringArg(args, "category_id"); v != "" {
+		form.Set("categoryId", v)
+	} else if v, _ := existing["categoryId"].(string); v != "" {
 		form.Set("categoryId", v)
 	}
 	if v := stringArg(args, "project_id"); v != "" {
@@ -341,20 +356,26 @@ func (s *Service) updateExpense(ctx context.Context, args map[string]any) (Resul
 	if v := stringArg(args, "task_id"); v != "" {
 		form.Set("taskId", v)
 	}
-	if v := stringArg(args, "user_id"); v != "" {
-		form.Set("userId", v)
+	userID := stringArg(args, "user_id")
+	if userID == "" {
+		current, err := s.getCurrentUser(ctx)
+		if err != nil {
+			return ResultEnvelope{}, fmt.Errorf("resolve user_id from current user: %w", err)
+		}
+		userID = current.ID
+	}
+	if userID != "" {
+		form.Set("userId", userID)
 	}
 	if v := stringArg(args, "notes"); v != "" {
 		form.Set("notes", v)
 	}
 	if v, ok := args["billable"].(bool); ok {
 		form.Set("billable", strconv.FormatBool(v))
+	} else if v, ok := existing["billable"].(bool); ok {
+		form.Set("billable", strconv.FormatBool(v))
 	}
 
-	path, err := paths.Workspace(wsID, "expenses", expenseID)
-	if err != nil {
-		return ResultEnvelope{}, err
-	}
 	var updated map[string]any
 	if err := s.Client.PutMultipart(ctx, path, form, &updated); err != nil {
 		return ResultEnvelope{}, err

--- a/internal/tools/tier2_financial_dispatch_test.go
+++ b/internal/tools/tier2_financial_dispatch_test.go
@@ -118,9 +118,11 @@ func TestTier2Dispatch_Invoices_Create(t *testing.T) {
 		Group: "invoices",
 		Tool:  "clockify_create_invoice",
 		Args: map[string]any{
-			"client_id": "client-1",
-			"currency":  "USD",
-			"due_date":  "2026-05-01",
+			"client_id":   "client-1",
+			"number":      "INV-DISPATCH",
+			"issued_date": "2026-04-01T00:00:00Z",
+			"currency":    "USD",
+			"due_date":    "2026-05-01T00:00:00Z",
 		},
 		Upstream: upstream,
 	})

--- a/internal/tools/tier2_invoices.go
+++ b/internal/tools/tier2_invoices.go
@@ -59,12 +59,14 @@ func invoiceHandlers(s *Service) []mcp.ToolDescriptor {
 		// 3. Create invoice
 		{Tool: toolRW("clockify_create_invoice", "Create a new invoice for a client", map[string]any{
 			"type":     "object",
-			"required": []string{"client_id"},
+			"required": []string{"client_id", "number", "issued_date", "due_date"},
 			"properties": map[string]any{
-				"client_id": map[string]any{"type": "string", "description": "Client ID (required)"},
-				"currency":  map[string]any{"type": "string", "description": "Currency code (e.g. USD, EUR)"},
-				"due_date":  map[string]any{"type": "string", "description": "Due date (YYYY-MM-DD)"},
-				"note":      map[string]any{"type": "string", "description": "Invoice note"},
+				"client_id":   map[string]any{"type": "string", "description": "Client ID (required)"},
+				"number":      map[string]any{"type": "string", "description": "Invoice number (required by live API)"},
+				"issued_date": map[string]any{"type": "string", "description": "Issued date (RFC3339 yyyy-MM-ddThh:mm:ssZ)"},
+				"currency":    map[string]any{"type": "string", "description": "Currency code (e.g. USD, EUR)"},
+				"due_date":    map[string]any{"type": "string", "description": "Due date (RFC3339 yyyy-MM-ddThh:mm:ssZ)"},
+				"note":        map[string]any{"type": "string", "description": "Invoice note"},
 			},
 		}), ReadOnlyHint: false, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.createInvoice(ctx, args)
@@ -75,12 +77,14 @@ func invoiceHandlers(s *Service) []mcp.ToolDescriptor {
 			"type":     "object",
 			"required": []string{"invoice_id"},
 			"properties": map[string]any{
-				"invoice_id": map[string]any{"type": "string"},
-				"client_id":  map[string]any{"type": "string"},
-				"currency":   map[string]any{"type": "string"},
-				"due_date":   map[string]any{"type": "string"},
-				"note":       map[string]any{"type": "string"},
-				"status":     map[string]any{"type": "string", "description": "Invoice status"},
+				"invoice_id":  map[string]any{"type": "string"},
+				"client_id":   map[string]any{"type": "string"},
+				"number":      map[string]any{"type": "string"},
+				"issued_date": map[string]any{"type": "string", "description": "Issued date (RFC3339 yyyy-MM-ddThh:mm:ssZ)"},
+				"currency":    map[string]any{"type": "string"},
+				"due_date":    map[string]any{"type": "string", "description": "Due date (RFC3339 yyyy-MM-ddThh:mm:ssZ)"},
+				"note":        map[string]any{"type": "string"},
+				"status":      map[string]any{"type": "string", "description": "Invoice status"},
 			},
 		}), ReadOnlyHint: false, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.updateInvoice(ctx, args)
@@ -136,12 +140,14 @@ func invoiceHandlers(s *Service) []mcp.ToolDescriptor {
 		// 9. Add invoice item
 		{Tool: toolRW("clockify_add_invoice_item", "Add an item to an invoice", map[string]any{
 			"type":     "object",
-			"required": []string{"invoice_id"},
+			"required": []string{"invoice_id", "item_type"},
 			"properties": map[string]any{
 				"invoice_id":  map[string]any{"type": "string"},
 				"description": map[string]any{"type": "string"},
 				"quantity":    map[string]any{"type": "number"},
-				"unit_price":  map[string]any{"type": "number"},
+				"unit_price":  map[string]any{"type": "number", "description": "Raw upstream unit price value; live API uses minor units/cents"},
+				"apply_taxes": map[string]any{"type": "string", "enum": []string{"TAX1", "TAX2", "TAX1TAX2", "NONE"}, "description": "Tax application enum; defaults to NONE"},
+				"item_type":   map[string]any{"type": "string", "description": "Workspace invoice item type name (required by live API; e.g. NEW DEFAULT in the sacrificial workspace)"},
 			},
 		}), ReadOnlyHint: false, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.addInvoiceItem(ctx, args)
@@ -150,13 +156,15 @@ func invoiceHandlers(s *Service) []mcp.ToolDescriptor {
 		// 10. Update invoice item
 		{Tool: toolRW("clockify_update_invoice_item", "Update an invoice item", map[string]any{
 			"type":     "object",
-			"required": []string{"invoice_id", "item_id"},
+			"required": []string{"invoice_id", "item_id", "item_type"},
 			"properties": map[string]any{
 				"invoice_id":  map[string]any{"type": "string"},
-				"item_id":     map[string]any{"type": "string"},
+				"item_id":     map[string]any{"type": "string", "description": "Invoice line order (live API path parameter), not a Mongo-style id"},
 				"description": map[string]any{"type": "string"},
 				"quantity":    map[string]any{"type": "number"},
-				"unit_price":  map[string]any{"type": "number"},
+				"unit_price":  map[string]any{"type": "number", "description": "Raw upstream unit price value; live API uses minor units/cents"},
+				"apply_taxes": map[string]any{"type": "string", "enum": []string{"TAX1", "TAX2", "TAX1TAX2", "NONE"}, "description": "Tax application enum; defaults to NONE"},
+				"item_type":   map[string]any{"type": "string", "description": "Workspace invoice item type name (required by live API)"},
 			},
 		}), ReadOnlyHint: false, Handler: func(ctx context.Context, args map[string]any) (any, error) {
 			return s.updateInvoiceItem(ctx, args)
@@ -168,7 +176,7 @@ func invoiceHandlers(s *Service) []mcp.ToolDescriptor {
 			"required": []string{"invoice_id", "item_id"},
 			"properties": map[string]any{
 				"invoice_id": map[string]any{"type": "string"},
-				"item_id":    map[string]any{"type": "string"},
+				"item_id":    map[string]any{"type": "string", "description": "Invoice line order (live API path parameter), not a Mongo-style id"},
 				"dry_run":    map[string]any{"type": "boolean"},
 			},
 		}), ReadOnlyHint: false, DestructiveHint: true, Handler: func(ctx context.Context, args map[string]any) (any, error) {
@@ -263,6 +271,12 @@ func (s *Service) createInvoice(ctx context.Context, args map[string]any) (Resul
 	}
 
 	body := map[string]any{"clientId": clientID}
+	if v := stringArg(args, "number"); v != "" {
+		body["number"] = v
+	}
+	if v := stringArg(args, "issued_date"); v != "" {
+		body["issuedDate"] = v
+	}
 	if v := stringArg(args, "currency"); v != "" {
 		body["currency"] = v
 	}
@@ -297,6 +311,12 @@ func (s *Service) updateInvoice(ctx context.Context, args map[string]any) (Resul
 	body := map[string]any{}
 	if v := stringArg(args, "client_id"); v != "" {
 		body["clientId"] = v
+	}
+	if v := stringArg(args, "number"); v != "" {
+		body["number"] = v
+	}
+	if v := stringArg(args, "issued_date"); v != "" {
+		body["issuedDate"] = v
 	}
 	if v := stringArg(args, "currency"); v != "" {
 		body["currency"] = v
@@ -425,7 +445,16 @@ func (s *Service) markInvoicePaid(ctx context.Context, args map[string]any) (Res
 		}, nil
 	}
 
+	var invoice map[string]any
+	if err := s.Client.Get(ctx, path, nil, &invoice); err != nil {
+		return ResultEnvelope{}, err
+	}
 	body := map[string]any{"status": "PAID"}
+	for _, key := range []string{"clientId", "number", "issuedDate", "dueDate", "currency", "note"} {
+		if v, ok := invoice[key]; ok {
+			body[key] = v
+		}
+	}
 	var updated map[string]any
 	if err := s.Client.Put(ctx, path, body, &updated); err != nil {
 		return ResultEnvelope{}, err
@@ -487,6 +516,16 @@ func (s *Service) addInvoiceItem(ctx context.Context, args map[string]any) (Resu
 	if v, ok := args["unit_price"]; ok {
 		body["unitPrice"] = v
 	}
+	if v := stringArg(args, "apply_taxes"); v != "" {
+		body["applyTaxes"] = v
+	} else {
+		body["applyTaxes"] = "NONE"
+	}
+	itemType := stringArg(args, "item_type")
+	if itemType == "" {
+		return ResultEnvelope{}, fmt.Errorf("item_type is required")
+	}
+	body["itemType"] = itemType
 
 	path, err := paths.Workspace(wsID, "invoices", invoiceID, "items")
 	if err != nil {
@@ -508,8 +547,8 @@ func (s *Service) updateInvoiceItem(ctx context.Context, args map[string]any) (R
 		return ResultEnvelope{}, err
 	}
 	itemID := stringArg(args, "item_id")
-	if err := resolve.ValidateID(itemID, "item_id"); err != nil {
-		return ResultEnvelope{}, err
+	if itemID == "" {
+		return ResultEnvelope{}, fmt.Errorf("item_id is required")
 	}
 	wsID, err := s.ResolveWorkspaceID(ctx)
 	if err != nil {
@@ -526,6 +565,16 @@ func (s *Service) updateInvoiceItem(ctx context.Context, args map[string]any) (R
 	if v, ok := args["unit_price"]; ok {
 		body["unitPrice"] = v
 	}
+	if v := stringArg(args, "apply_taxes"); v != "" {
+		body["applyTaxes"] = v
+	} else {
+		body["applyTaxes"] = "NONE"
+	}
+	itemType := stringArg(args, "item_type")
+	if itemType == "" {
+		return ResultEnvelope{}, fmt.Errorf("item_type is required")
+	}
+	body["itemType"] = itemType
 
 	path, err := paths.Workspace(wsID, "invoices", invoiceID, "items", itemID)
 	if err != nil {
@@ -548,8 +597,8 @@ func (s *Service) deleteInvoiceItem(ctx context.Context, args map[string]any) (R
 		return ResultEnvelope{}, err
 	}
 	itemID := stringArg(args, "item_id")
-	if err := resolve.ValidateID(itemID, "item_id"); err != nil {
-		return ResultEnvelope{}, err
+	if itemID == "" {
+		return ResultEnvelope{}, fmt.Errorf("item_id is required")
 	}
 	wsID, err := s.ResolveWorkspaceID(ctx)
 	if err != nil {

--- a/internal/tools/tier2_invoices_test.go
+++ b/internal/tools/tier2_invoices_test.go
@@ -36,10 +36,14 @@ func TestTier2_Invoices_FullSweep(t *testing.T) {
 			})
 		case r.Method == "GET" && r.URL.Path == "/workspaces/ws1/invoices/inv1":
 			respondJSON(t, w, map[string]any{
-				"id":       "inv1",
-				"status":   "DRAFT",
-				"currency": "USD",
-				"items":    []map[string]any{{"id": "item1", "description": "Hour"}},
+				"id":         "inv1",
+				"clientId":   "c1",
+				"number":     "INV-1",
+				"issuedDate": "2026-04-01T00:00:00Z",
+				"dueDate":    "2026-05-01T00:00:00Z",
+				"status":     "DRAFT",
+				"currency":   "USD",
+				"items":      []map[string]any{{"id": "item1", "description": "Hour"}},
 			})
 		case r.Method == "POST" && r.URL.Path == "/workspaces/ws1/invoices":
 			respondJSON(t, w, map[string]any{"id": "inv-new", "clientId": "c1", "status": "DRAFT"})
@@ -82,10 +86,12 @@ func TestTier2_Invoices_FullSweep(t *testing.T) {
 
 	// 3. createInvoice — happy
 	res, err = svc.createInvoice(ctx, map[string]any{
-		"client_id": "c1",
-		"currency":  "USD",
-		"due_date":  "2026-05-01",
-		"note":      "Q2 invoice",
+		"client_id":   "c1",
+		"number":      "INV-NEW",
+		"issued_date": "2026-04-01T00:00:00Z",
+		"currency":    "USD",
+		"due_date":    "2026-05-01T00:00:00Z",
+		"note":        "Q2 invoice",
 	})
 	mustOK(t, res, err, "clockify_create_invoice")
 
@@ -96,12 +102,14 @@ func TestTier2_Invoices_FullSweep(t *testing.T) {
 
 	// 4. updateInvoice — happy
 	res, err = svc.updateInvoice(ctx, map[string]any{
-		"invoice_id": "inv1",
-		"client_id":  "c1",
-		"currency":   "EUR",
-		"due_date":   "2026-06-01",
-		"note":       "updated",
-		"status":     "SENT",
+		"invoice_id":  "inv1",
+		"client_id":   "c1",
+		"number":      "INV-1A",
+		"issued_date": "2026-04-02T00:00:00Z",
+		"currency":    "EUR",
+		"due_date":    "2026-06-01T00:00:00Z",
+		"note":        "updated",
+		"status":      "SENT",
 	})
 	mustOK(t, res, err, "clockify_update_invoice")
 
@@ -177,6 +185,7 @@ func TestTier2_Invoices_FullSweep(t *testing.T) {
 		"description": "Consulting",
 		"quantity":    8,
 		"unit_price":  150,
+		"item_type":   "NEW DEFAULT",
 	})
 	mustOK(t, res, err, "clockify_add_invoice_item")
 
@@ -192,6 +201,7 @@ func TestTier2_Invoices_FullSweep(t *testing.T) {
 		"description": "Updated description",
 		"quantity":    10,
 		"unit_price":  175,
+		"item_type":   "NEW DEFAULT",
 	})
 	mustOK(t, res, err, "clockify_update_invoice_item")
 

--- a/internal/tools/tier2_time_off.go
+++ b/internal/tools/tier2_time_off.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/apet97/go-clockify/internal/dryrun"
 	"github.com/apet97/go-clockify/internal/mcp"
@@ -67,11 +68,11 @@ func timeOffHandlers(s *Service) []mcp.ToolDescriptor {
 		{
 			Tool: toolRW("clockify_create_time_off_request",
 				"Create a time off request under a policy",
-				map[string]any{"type": "object", "required": []string{"policy_id", "start", "end"}, "properties": map[string]any{
+				map[string]any{"type": "object", "required": []string{"policy_id", "start", "end", "note"}, "properties": map[string]any{
 					"policy_id": map[string]any{"type": "string"},
 					"start":     map[string]any{"type": "string", "description": "Start date (YYYY-MM-DD or RFC3339)"},
 					"end":       map[string]any{"type": "string", "description": "End date (YYYY-MM-DD or RFC3339)"},
-					"note":      map[string]any{"type": "string", "description": "Optional note/reason"},
+					"note":      map[string]any{"type": "string", "description": "Required note/reason"},
 					"half_day":  map[string]any{"type": "boolean", "description": "Request half day"},
 				}}),
 			ReadOnlyHint: false,
@@ -86,10 +87,12 @@ func timeOffHandlers(s *Service) []mcp.ToolDescriptor {
 				map[string]any{"type": "object", "required": []string{"policy_id", "request_id"}, "properties": map[string]any{
 					"policy_id":  map[string]any{"type": "string"},
 					"request_id": map[string]any{"type": "string"},
-					"start":      map[string]any{"type": "string"},
-					"end":        map[string]any{"type": "string"},
 					"note":       map[string]any{"type": "string"},
-					"half_day":   map[string]any{"type": "boolean"},
+					"status": map[string]any{
+						"type":        "string",
+						"description": "Status to set via Clockify's PATCH route",
+						"enum":        []string{"APPROVED", "REJECTED"},
+					},
 				}}),
 			ReadOnlyHint: false,
 			Handler: func(ctx context.Context, args map[string]any) (any, error) {
@@ -310,21 +313,33 @@ func (s *Service) createTimeOffRequest(ctx context.Context, args map[string]any)
 	if startRaw == "" || endRaw == "" {
 		return ResultEnvelope{}, fmt.Errorf("start and end are required")
 	}
+	note := stringArg(args, "note")
+	if note == "" {
+		return ResultEnvelope{}, fmt.Errorf("note is required")
+	}
+	days, err := timeOffRequestDays(startRaw, endRaw)
+	if err != nil {
+		return ResultEnvelope{}, err
+	}
 
 	wsID, err := s.ResolveWorkspaceID(ctx)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
 
+	halfDay, _ := args["half_day"].(bool)
 	payload := map[string]any{
-		"start": startRaw,
-		"end":   endRaw,
-	}
-	if note := stringArg(args, "note"); note != "" {
-		payload["note"] = note
-	}
-	if halfDay, ok := args["half_day"].(bool); ok {
-		payload["halfDay"] = halfDay
+		"note": note,
+		"timeOffPeriod": map[string]any{
+			"period": map[string]any{
+				"start": startRaw,
+				"end":   endRaw,
+				"days":  days,
+			},
+			"isHalfDay":            halfDay,
+			"halfDayPeriod":        "NOT_DEFINED",
+			"timeOffHalfDayPeriod": "NOT_DEFINED",
+		},
 	}
 
 	var result map[string]any
@@ -342,6 +357,23 @@ func (s *Service) createTimeOffRequest(ctx context.Context, args map[string]any)
 	}), nil
 }
 
+func timeOffRequestDays(startRaw, endRaw string) (int, error) {
+	start, err := parseFlexibleDateTime(startRaw, time.UTC)
+	if err != nil {
+		return 0, fmt.Errorf("start: %w", err)
+	}
+	end, err := parseFlexibleDateTime(endRaw, time.UTC)
+	if err != nil {
+		return 0, fmt.Errorf("end: %w", err)
+	}
+	startDay := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+	endDay := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, time.UTC)
+	if endDay.Before(startDay) {
+		return 0, fmt.Errorf("end must be on or after start")
+	}
+	return int(endDay.Sub(startDay).Hours()/24) + 1, nil
+}
+
 func (s *Service) updateTimeOffRequest(ctx context.Context, args map[string]any) (ResultEnvelope, error) {
 	policyID := stringArg(args, "policy_id")
 	requestID := stringArg(args, "request_id")
@@ -357,36 +389,30 @@ func (s *Service) updateTimeOffRequest(ctx context.Context, args map[string]any)
 		return ResultEnvelope{}, err
 	}
 
-	// Fetch existing for merge
-	var existing map[string]any
 	path, err := paths.Workspace(wsID, "time-off", "policies", policyID, "requests", requestID)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
-	if err := s.Client.Get(ctx, path, nil, &existing); err != nil {
-		return ResultEnvelope{}, err
-	}
 
-	changed := make([]string, 0, 4)
-	if v := stringArg(args, "start"); v != "" {
-		existing["start"] = v
-		changed = append(changed, "start")
-	}
-	if v := stringArg(args, "end"); v != "" {
-		existing["end"] = v
-		changed = append(changed, "end")
-	}
+	body := map[string]any{}
+	changed := make([]string, 0, 2)
 	if v := stringArg(args, "note"); v != "" {
-		existing["note"] = v
+		body["note"] = v
 		changed = append(changed, "note")
 	}
-	if halfDay, ok := args["half_day"].(bool); ok {
-		existing["halfDay"] = halfDay
-		changed = append(changed, "halfDay")
+	if status := stringArg(args, "status"); status != "" {
+		if status != "APPROVED" && status != "REJECTED" {
+			return ResultEnvelope{}, fmt.Errorf("status must be APPROVED or REJECTED; got %q", status)
+		}
+		body["status"] = status
+		changed = append(changed, "status")
+	}
+	if len(body) == 0 {
+		return ResultEnvelope{}, fmt.Errorf("at least one field (note, status) must be provided for update")
 	}
 
 	var result map[string]any
-	if err := s.Client.Put(ctx, path, existing, &result); err != nil {
+	if err := s.Client.Patch(ctx, path, body, &result); err != nil {
 		return ResultEnvelope{}, err
 	}
 
@@ -464,11 +490,11 @@ func (s *Service) approveTimeOff(ctx context.Context, args map[string]any) (Resu
 	}
 
 	var result map[string]any
-	path, err := paths.Workspace(wsID, "time-off", "policies", policyID, "requests", requestID, "approve")
+	path, err := paths.Workspace(wsID, "time-off", "policies", policyID, "requests", requestID)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
-	if err := s.Client.Put(ctx, path, payload, &result); err != nil {
+	if err := s.Client.Patch(ctx, path, payload, &result); err != nil {
 		return ResultEnvelope{}, err
 	}
 
@@ -495,18 +521,18 @@ func (s *Service) denyTimeOff(ctx context.Context, args map[string]any) (ResultE
 	}
 
 	payload := map[string]any{
-		"status": "DENIED",
+		"status": "REJECTED",
 	}
 	if note := stringArg(args, "note"); note != "" {
 		payload["note"] = note
 	}
 
 	var result map[string]any
-	path, err := paths.Workspace(wsID, "time-off", "policies", policyID, "requests", requestID, "deny")
+	path, err := paths.Workspace(wsID, "time-off", "policies", policyID, "requests", requestID)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
-	if err := s.Client.Put(ctx, path, payload, &result); err != nil {
+	if err := s.Client.Patch(ctx, path, payload, &result); err != nil {
 		return ResultEnvelope{}, err
 	}
 

--- a/internal/tools/tier2_timemgmt_test.go
+++ b/internal/tools/tier2_timemgmt_test.go
@@ -126,8 +126,7 @@ func TestCreateTimeOffRequest(t *testing.T) {
 			respondJSON(t, w, map[string]any{
 				"id":       "req1",
 				"policyId": "pol1",
-				"start":    gotBody["start"],
-				"end":      gotBody["end"],
+				"period":   gotBody["timeOffPeriod"],
 				"status":   "PENDING",
 				"note":     gotBody["note"],
 			})
@@ -161,8 +160,13 @@ func TestCreateTimeOffRequest(t *testing.T) {
 		t.Fatalf("expected status PENDING, got %v", data["status"])
 	}
 	// Verify POST body
-	if gotBody["start"] != "2026-05-01" {
-		t.Fatalf("expected start 2026-05-01 in body, got %v", gotBody["start"])
+	periodEnvelope, _ := gotBody["timeOffPeriod"].(map[string]any)
+	period, _ := periodEnvelope["period"].(map[string]any)
+	if period["start"] != "2026-05-01" {
+		t.Fatalf("expected nested period.start 2026-05-01 in body, got %#v", gotBody)
+	}
+	if period["days"] != float64(5) {
+		t.Fatalf("expected nested period.days 5 in body, got %#v", gotBody)
 	}
 	if gotBody["note"] != "Family vacation" {
 		t.Fatalf("expected note in body, got %v", gotBody["note"])

--- a/internal/tools/tier2_webhooks.go
+++ b/internal/tools/tier2_webhooks.go
@@ -67,15 +67,24 @@ func webhookHandlers(s *Service) []mcp.ToolDescriptor {
 		{
 			Tool: toolRW("clockify_create_webhook", "Create a new webhook. URL must use HTTPS and cannot target private/loopback addresses.", map[string]any{
 				"type":     "object",
-				"required": []string{"url", "events"},
+				"required": []string{"name", "url", "webhook_event"},
 				"properties": map[string]any{
 					"url": map[string]any{"type": "string", "description": "HTTPS callback URL for webhook delivery"},
-					"events": map[string]any{
+					"webhook_event": map[string]any{
+						"type":        "string",
+						"description": "Single Clockify webhook event type, e.g. NEW_TIME_ENTRY",
+					},
+					"trigger_source_type": map[string]any{
+						"type":        "string",
+						"description": "Trigger source type (default WORKSPACE_ID)",
+						"enum":        []string{"PROJECT_ID", "USER_ID", "TAG_ID", "TASK_ID", "WORKSPACE_ID", "ASSIGNMENT_ID", "EXPENSE_ID"},
+					},
+					"trigger_source": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string"},
-						"description": "List of event types to subscribe to",
+						"description": "Trigger source IDs (default: current workspace ID)",
 					},
-					"name": map[string]any{"type": "string", "description": "Optional name for the webhook"},
+					"name": map[string]any{"type": "string", "description": "Webhook name (required by live API)"},
 				},
 			}),
 			ReadOnlyHint: false,
@@ -91,10 +100,19 @@ func webhookHandlers(s *Service) []mcp.ToolDescriptor {
 				"properties": map[string]any{
 					"webhook_id": map[string]any{"type": "string", "description": "Webhook ID"},
 					"url":        map[string]any{"type": "string", "description": "New HTTPS callback URL"},
-					"events": map[string]any{
+					"webhook_event": map[string]any{
+						"type":        "string",
+						"description": "Single Clockify webhook event type",
+					},
+					"trigger_source_type": map[string]any{
+						"type":        "string",
+						"description": "Trigger source type",
+						"enum":        []string{"PROJECT_ID", "USER_ID", "TAG_ID", "TASK_ID", "WORKSPACE_ID", "ASSIGNMENT_ID", "EXPENSE_ID"},
+					},
+					"trigger_source": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string"},
-						"description": "New list of event types",
+						"description": "Trigger source IDs",
 					},
 					"name": map[string]any{"type": "string", "description": "New name for the webhook"},
 				},
@@ -340,6 +358,32 @@ func stringSliceArg(args map[string]any, key string) []string {
 	}
 }
 
+func webhookEventArg(args map[string]any) string {
+	if event := stringArg(args, "webhook_event"); event != "" {
+		return event
+	}
+	// Backwards-compatible handler path for callers that bypass the MCP
+	// schema and still pass the pre-live-test `events` array. The live API
+	// accepts one webhookEvent string per webhook.
+	events := stringSliceArg(args, "events")
+	if len(events) > 0 {
+		return events[0]
+	}
+	return ""
+}
+
+func webhookTriggerSourceArgs(args map[string]any, workspaceID string) (string, []string) {
+	sourceType := stringArg(args, "trigger_source_type")
+	if sourceType == "" {
+		sourceType = "WORKSPACE_ID"
+	}
+	source := stringSliceArg(args, "trigger_source")
+	if len(source) == 0 {
+		source = []string{workspaceID}
+	}
+	return sourceType, source
+}
+
 // ListWebhooks returns webhooks for the workspace.
 func (s *Service) ListWebhooks(ctx context.Context, args map[string]any) (ResultEnvelope, error) {
 	wsID, err := s.ResolveWorkspaceID(ctx)
@@ -412,23 +456,28 @@ func (s *Service) CreateWebhook(ctx context.Context, args map[string]any) (Resul
 	if err := s.validateWebhookURLForService(ctx, url); err != nil {
 		return ResultEnvelope{}, err
 	}
+	name := stringArg(args, "name")
+	if name == "" {
+		return ResultEnvelope{}, fmt.Errorf("name is required")
+	}
 
-	events := stringSliceArg(args, "events")
-	if len(events) == 0 {
-		return ResultEnvelope{}, fmt.Errorf("events is required and must contain at least one event type")
+	webhookEvent := webhookEventArg(args)
+	if webhookEvent == "" {
+		return ResultEnvelope{}, fmt.Errorf("webhook_event is required")
 	}
 
 	wsID, err := s.ResolveWorkspaceID(ctx)
 	if err != nil {
 		return ResultEnvelope{}, err
 	}
+	triggerSourceType, triggerSource := webhookTriggerSourceArgs(args, wsID)
 
 	payload := map[string]any{
-		"url":    url,
-		"events": events,
-	}
-	if name := stringArg(args, "name"); name != "" {
-		payload["name"] = name
+		"url":               url,
+		"webhookEvent":      webhookEvent,
+		"triggerSourceType": triggerSourceType,
+		"triggerSource":     triggerSource,
+		"name":              name,
 	}
 
 	path, err := paths.Workspace(wsID, "webhooks")
@@ -455,27 +504,49 @@ func (s *Service) UpdateWebhook(ctx context.Context, args map[string]any) (Resul
 		return ResultEnvelope{}, err
 	}
 
+	path, err := paths.Workspace(wsID, "webhooks", webhookID)
+	if err != nil {
+		return ResultEnvelope{}, err
+	}
+
+	var existing map[string]any
+	if err := s.Client.Get(ctx, path, nil, &existing); err != nil {
+		return ResultEnvelope{}, err
+	}
+
 	payload := map[string]any{}
+	for _, key := range []string{"name", "url", "webhookEvent", "triggerSourceType", "triggerSource"} {
+		if v, ok := existing[key]; ok {
+			payload[key] = v
+		}
+	}
+	changed := false
 	if url := stringArg(args, "url"); url != "" {
 		if err := s.validateWebhookURLForService(ctx, url); err != nil {
 			return ResultEnvelope{}, err
 		}
 		payload["url"] = url
+		changed = true
 	}
-	if events := stringSliceArg(args, "events"); len(events) > 0 {
-		payload["events"] = events
+	if event := webhookEventArg(args); event != "" {
+		payload["webhookEvent"] = event
+		changed = true
+	}
+	if sourceType := stringArg(args, "trigger_source_type"); sourceType != "" {
+		payload["triggerSourceType"] = sourceType
+		changed = true
+	}
+	if source := stringSliceArg(args, "trigger_source"); len(source) > 0 {
+		payload["triggerSource"] = source
+		changed = true
 	}
 	if name := stringArg(args, "name"); name != "" {
 		payload["name"] = name
+		changed = true
 	}
 
-	if len(payload) == 0 {
-		return ResultEnvelope{}, fmt.Errorf("at least one field (url, events, name) must be provided for update")
-	}
-
-	path, err := paths.Workspace(wsID, "webhooks", webhookID)
-	if err != nil {
-		return ResultEnvelope{}, err
+	if !changed {
+		return ResultEnvelope{}, fmt.Errorf("at least one field (url, webhook_event, trigger_source_type, trigger_source, name) must be provided for update")
 	}
 	var result map[string]any
 	if err := s.Client.Put(ctx, path, payload, &result); err != nil {

--- a/internal/tools/tier2_webhooks_test.go
+++ b/internal/tools/tier2_webhooks_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -100,5 +101,102 @@ func TestListWebhooks(t *testing.T) {
 	}
 	if result.Meta["workspaceWebhookCount"] != 2 {
 		t.Fatalf("expected meta workspaceWebhookCount=2, got %v", result.Meta["workspaceWebhookCount"])
+	}
+}
+
+func TestCreateWebhookUsesSingularEventAndTriggerSource(t *testing.T) {
+	var gotBody map[string]any
+	client, cleanup := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/workspaces/ws1/webhooks" && r.Method == http.MethodPost:
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			respondJSON(t, w, map[string]any{
+				"id":                "wh1",
+				"name":              gotBody["name"],
+				"url":               gotBody["url"],
+				"webhookEvent":      gotBody["webhookEvent"],
+				"triggerSourceType": gotBody["triggerSourceType"],
+				"triggerSource":     gotBody["triggerSource"],
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer cleanup()
+
+	svc := New(client, "ws1")
+	result, err := svc.CreateWebhook(context.Background(), map[string]any{
+		"name":                "live webhook",
+		"url":                 "https://example.com/hook",
+		"webhook_event":       "NEW_TIME_ENTRY",
+		"trigger_source_type": "WORKSPACE_ID",
+		"trigger_source":      []any{"ws1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateWebhook failed: %v", err)
+	}
+	if result.Action != "clockify_create_webhook" {
+		t.Fatalf("expected create action, got %q", result.Action)
+	}
+	if gotBody["webhookEvent"] != "NEW_TIME_ENTRY" {
+		t.Fatalf("expected singular webhookEvent, got body %#v", gotBody)
+	}
+	if _, ok := gotBody["events"]; ok {
+		t.Fatalf("body must not use legacy events array: %#v", gotBody)
+	}
+}
+
+func TestUpdateWebhookCarriesRequiredLiveFields(t *testing.T) {
+	var gotBody map[string]any
+	client, cleanup := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/workspaces/ws1/webhooks/wh1" && r.Method == http.MethodGet:
+			respondJSON(t, w, map[string]any{
+				"id":                "wh1",
+				"name":              "old",
+				"url":               "https://example.com/old",
+				"webhookEvent":      "NEW_TIME_ENTRY",
+				"triggerSourceType": "WORKSPACE_ID",
+				"triggerSource":     []string{"ws1"},
+			})
+		case r.URL.Path == "/workspaces/ws1/webhooks/wh1" && r.Method == http.MethodPut:
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			respondJSON(t, w, map[string]any{
+				"id":                "wh1",
+				"name":              gotBody["name"],
+				"url":               gotBody["url"],
+				"webhookEvent":      gotBody["webhookEvent"],
+				"triggerSourceType": gotBody["triggerSourceType"],
+				"triggerSource":     gotBody["triggerSource"],
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer cleanup()
+
+	svc := New(client, "ws1")
+	result, err := svc.UpdateWebhook(context.Background(), map[string]any{
+		"webhook_id":    "wh1",
+		"name":          "new",
+		"webhook_event": "TIMER_STOPPED",
+	})
+	if err != nil {
+		t.Fatalf("UpdateWebhook failed: %v", err)
+	}
+	if result.Action != "clockify_update_webhook" {
+		t.Fatalf("expected update action, got %q", result.Action)
+	}
+	for _, key := range []string{"name", "url", "webhookEvent", "triggerSourceType", "triggerSource"} {
+		if gotBody[key] == nil {
+			t.Fatalf("update body missing required live field %q: %#v", key, gotBody)
+		}
+	}
+	if gotBody["webhookEvent"] != "TIMER_STOPPED" {
+		t.Fatalf("expected updated event, got body %#v", gotBody)
 	}
 }

--- a/internal/tools/tier2_writes_bench_test.go
+++ b/internal/tools/tier2_writes_bench_test.go
@@ -130,10 +130,12 @@ func BenchmarkClockifyCreateExpense(b *testing.B) {
 func BenchmarkClockifyCreateInvoice(b *testing.B) {
 	invokeTier2WriteBench(b, "clockify_create_invoice", []string{"invoices"}, func() map[string]any {
 		return map[string]any{
-			"client_id": "c-bench",
-			"currency":  "USD",
-			"due_date":  "2026-02-01",
-			"note":      "bench",
+			"client_id":   "c-bench",
+			"number":      "INV-BENCH",
+			"issued_date": "2026-01-01T00:00:00Z",
+			"currency":    "USD",
+			"due_date":    "2026-02-01T00:00:00Z",
+			"note":        "bench",
 		}
 	})
 }
@@ -157,8 +159,8 @@ func BenchmarkClockifyCreateCustomField(b *testing.B) {
 func BenchmarkClockifySubmitForApproval(b *testing.B) {
 	invokeTier2WriteBench(b, "clockify_submit_for_approval", []string{"approvals"}, func() map[string]any {
 		return map[string]any{
-			"start": "2026-01-01T00:00:00Z",
-			"end":   "2026-01-07T23:59:59Z",
+			"period":       "WEEKLY",
+			"period_start": "2026-01-01T00:00:00.000Z",
 		}
 	})
 }

--- a/tests/e2e_live_t2_expenses_test.go
+++ b/tests/e2e_live_t2_expenses_test.go
@@ -23,6 +23,8 @@ func TestLiveT2ExpensesCRUD(t *testing.T) {
 
 	categoryName := c.LivePrefix("exp-cat", 0)
 	var categoryID string
+	var expenseID string
+	var expenseDeleted bool
 
 	t.Run("create_expense_category", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -127,9 +129,53 @@ func TestLiveT2ExpensesCRUD(t *testing.T) {
 		if id == "" {
 			t.Fatalf("create_expense returned no id: %#v", data)
 		}
+		expenseID = id
 		c.RegisterCleanup("expense", id, func(ctx context.Context) error {
+			if expenseDeleted {
+				return nil
+			}
 			return c.rawDeletePath(ctx, "/expenses/"+id)
 		})
+	})
+
+	t.Run("get_update_delete_expense_cycle", func(t *testing.T) {
+		if expenseID == "" || categoryID == "" {
+			t.Skip("create_expense did not produce required ids")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+
+		got := h.callOK(ctx, "clockify_get_expense", map[string]any{
+			"expense_id": expenseID,
+		})
+		if gotID, _ := extractDataMap(t, got)["id"].(string); gotID != expenseID {
+			t.Fatalf("get_expense id mismatch: got %q want %q", gotID, expenseID)
+		}
+
+		updated := h.callOK(ctx, "clockify_update_expense", map[string]any{
+			"expense_id":    expenseID,
+			"change_fields": []any{"NOTES", "AMOUNT"},
+			"notes":         c.LivePrefix("exp-updated", 0),
+			"amount":        2.0,
+		})
+		if updatedID, _ := extractDataMap(t, updated)["id"].(string); updatedID != expenseID {
+			t.Fatalf("update_expense id mismatch: got %q want %q", updatedID, expenseID)
+		}
+
+		dry := h.callOK(ctx, "clockify_delete_expense", map[string]any{
+			"expense_id": expenseID,
+			"dry_run":    true,
+		})
+		sc, _ := dry["structuredContent"].(map[string]any)
+		data, _ := sc["data"].(map[string]any)
+		if dryRun, _ := data["dry_run"].(bool); !dryRun {
+			t.Fatalf("delete_expense dry_run did not return dry_run:true envelope: %#v", sc)
+		}
+
+		_ = h.callOK(ctx, "clockify_delete_expense", map[string]any{
+			"expense_id": expenseID,
+		})
+		expenseDeleted = true
 	})
 
 	t.Run("get_expense_rejects_nonexistent_id", func(t *testing.T) {

--- a/tests/e2e_live_t2_invoices_test.go
+++ b/tests/e2e_live_t2_invoices_test.go
@@ -1,0 +1,155 @@
+//go:build livee2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apet97/go-clockify/internal/policy"
+)
+
+func TestLiveT2InvoicesCRUD(t *testing.T) {
+	requireCategory(t, "CLOCKIFY_LIVE_BILLING_ENABLED")
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Full})
+	c := setupLiveCampaign(t, h)
+	c.activateTier2("invoices")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	client := h.callOK(ctx, "clockify_create_client", map[string]any{
+		"name": c.LivePrefix("invoice-client", 0),
+	})
+	clientID, _ := extractDataMap(t, client)["id"].(string)
+	if clientID == "" {
+		t.Fatalf("clockify_create_client returned no id: %#v", client)
+	}
+	c.RegisterCleanup("client", clientID, func(ctx context.Context) error {
+		return c.rawArchiveAndDeleteClient(ctx, clientID)
+	})
+
+	issuedDate := time.Now().UTC().Truncate(time.Second).Format("2006-01-02T15:04:05Z")
+	dueDate := time.Now().UTC().AddDate(0, 0, 14).Truncate(time.Second).Format("2006-01-02T15:04:05Z")
+	invoice := h.callOK(ctx, "clockify_create_invoice", map[string]any{
+		"client_id":   clientID,
+		"number":      c.LivePrefix("inv", 0),
+		"issued_date": issuedDate,
+		"currency":    "USD",
+		"due_date":    dueDate,
+		"note":        c.LivePrefix("invoice", 0),
+	})
+	invoiceID, _ := extractDataMap(t, invoice)["id"].(string)
+	if invoiceID == "" {
+		t.Fatalf("clockify_create_invoice returned no id: %#v", invoice)
+	}
+	invoiceDeleted := false
+	c.RegisterCleanup("invoice", invoiceID, func(ctx context.Context) error {
+		if invoiceDeleted {
+			return nil
+		}
+		return c.rawDeletePath(ctx, "/invoices/"+invoiceID)
+	})
+
+	_ = h.callOK(ctx, "clockify_list_invoices", map[string]any{"page": 1, "page_size": 5})
+	got := h.callOK(ctx, "clockify_get_invoice", map[string]any{"invoice_id": invoiceID})
+	if gotID, _ := extractDataMap(t, got)["id"].(string); gotID != invoiceID {
+		t.Fatalf("clockify_get_invoice id mismatch: got %q want %q", gotID, invoiceID)
+	}
+
+	updated := h.callOK(ctx, "clockify_update_invoice", map[string]any{
+		"invoice_id":  invoiceID,
+		"client_id":   clientID,
+		"number":      c.LivePrefix("inv", 1),
+		"issued_date": issuedDate,
+		"currency":    "USD",
+		"due_date":    dueDate,
+		"note":        c.LivePrefix("invoice-updated", 0),
+	})
+	if updatedID, _ := extractDataMap(t, updated)["id"].(string); updatedID != invoiceID {
+		t.Fatalf("clockify_update_invoice id mismatch: got %q want %q", updatedID, invoiceID)
+	}
+
+	item := h.callOK(ctx, "clockify_add_invoice_item", map[string]any{
+		"invoice_id":  invoiceID,
+		"description": c.LivePrefix("invoice-item", 0),
+		"quantity":    100.0,
+		// Raw minor-unit value, passed through without conversion.
+		"unit_price":  1000.0,
+		"apply_taxes": "NONE",
+		"item_type":   "NEW DEFAULT",
+	})
+	itemID, _ := extractDataMap(t, item)["id"].(string)
+	if itemID == "" {
+		t.Logf("clockify_add_invoice_item returned no line-item id; per-item mutation routes are probed as unsupported: %#v", item)
+		itemID = "000000000000000000000001"
+	}
+
+	items := h.callOK(ctx, "clockify_list_invoice_items", map[string]any{"invoice_id": invoiceID})
+	itemRows := extractList(t, items)
+	if len(itemRows) == 0 {
+		t.Fatalf("clockify_list_invoice_items returned no items after add: %#v", items)
+	}
+	if first, ok := itemRows[0].(map[string]any); ok {
+		if order, ok := first["order"].(float64); ok {
+			itemID = fmt.Sprintf("%.0f", order)
+		}
+	}
+	if itemID == "" {
+		t.Fatalf("clockify_list_invoice_items returned no line order: %#v", itemRows[0])
+	}
+
+	updateItemErr := h.callExpectError(ctx, "clockify_update_invoice_item", map[string]any{
+		"invoice_id":  invoiceID,
+		"item_id":     itemID,
+		"description": c.LivePrefix("invoice-item-updated", 0),
+		"quantity":    100.0,
+		"unit_price":  2000.0,
+		"apply_taxes": "NONE",
+		"item_type":   "NEW DEFAULT",
+	})
+	if !containsAny(updateItemErr, "not supported", "not found", "doesn't belong") {
+		t.Fatalf("expected live unsupported/not-found response for update_invoice_item, got: %q", updateItemErr)
+	}
+
+	_ = h.callOK(ctx, "clockify_delete_invoice_item", map[string]any{
+		"invoice_id": invoiceID,
+		"item_id":    itemID,
+	})
+
+	_ = h.callOK(ctx, "clockify_send_invoice", map[string]any{
+		"invoice_id": invoiceID,
+		"dry_run":    true,
+	})
+	_ = h.callOK(ctx, "clockify_mark_invoice_paid", map[string]any{
+		"invoice_id": invoiceID,
+		"dry_run":    true,
+	})
+	_ = h.callOK(ctx, "clockify_mark_invoice_paid", map[string]any{
+		"invoice_id": invoiceID,
+	})
+
+	_ = h.callOK(ctx, "clockify_invoice_report", map[string]any{"page": 1, "page_size": 5})
+	_ = h.callOK(ctx, "clockify_delete_invoice", map[string]any{
+		"invoice_id": invoiceID,
+		"dry_run":    true,
+	})
+	_ = h.callOK(ctx, "clockify_delete_invoice", map[string]any{
+		"invoice_id": invoiceID,
+	})
+	invoiceDeleted = true
+}
+
+func containsAny(s string, needles ...string) bool {
+	lower := strings.ToLower(s)
+	for _, needle := range needles {
+		if strings.Contains(lower, strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e_live_t2_shared_reports_test.go
+++ b/tests/e2e_live_t2_shared_reports_test.go
@@ -1,0 +1,126 @@
+//go:build livee2e
+
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apet97/go-clockify/internal/policy"
+)
+
+func TestLiveT2SharedReportsCRUDAndExports(t *testing.T) {
+	requireCategory(t, "CLOCKIFY_LIVE_FULL_SURFACE_ENABLED")
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Full})
+	c := setupLiveCampaign(t, h)
+	c.activateTier2("shared_reports")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	now := time.Now().UTC()
+	startAt := time.Date(now.Year(), now.Month()-1, now.Day(), 0, 0, 0, 0, time.UTC)
+	endAt := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, int(999*time.Millisecond), time.UTC)
+	start := startAt.Format("2006-01-02T15:04:05.000Z")
+	end := endAt.Format("2006-01-02T15:04:05.000Z")
+	summaryFilter := map[string]any{
+		"exportType":     "JSON_V1",
+		"dateRangeStart": start,
+		"dateRangeEnd":   end,
+		"sortOrder":      "DESCENDING",
+		"summaryFilter": map[string]any{
+			"groups":     []any{"PROJECT"},
+			"sortColumn": "GROUP",
+		},
+	}
+
+	created := h.callOK(ctx, "clockify_create_shared_report", map[string]any{
+		"name":        c.LivePrefix("shared-summary", 0),
+		"report_type": "SUMMARY",
+		"filter":      summaryFilter,
+	})
+	reportID, _ := extractDataMap(t, created)["id"].(string)
+	if reportID == "" {
+		t.Fatalf("clockify_create_shared_report returned no id: %#v", created)
+	}
+	reportDeleted := false
+	c.RegisterCleanup("shared-report", reportID, func(ctx context.Context) error {
+		if reportDeleted {
+			return nil
+		}
+		return h.Service.Client.DeleteReports(ctx, "/workspaces/"+c.WorkspaceID+"/shared-reports/"+reportID)
+	})
+
+	updated := h.callOK(ctx, "clockify_update_shared_report", map[string]any{
+		"report_id": reportID,
+		"name":      c.LivePrefix("shared-renamed", 0),
+	})
+	if updatedID, _ := extractDataMap(t, updated)["id"].(string); updatedID != reportID {
+		t.Fatalf("clockify_update_shared_report id mismatch: got %q want %q", updatedID, reportID)
+	}
+
+	got := h.callOK(ctx, "clockify_get_shared_report", map[string]any{"report_id": reportID})
+	if filters, ok := extractDataMap(t, got)["filters"].(map[string]any); !ok || filters["type"] != "SUMMARY" {
+		t.Fatalf("clockify_get_shared_report did not return SUMMARY filters: %#v", got)
+	}
+
+	jsonExport := h.callOK(ctx, "clockify_export_shared_report", map[string]any{
+		"report_id": reportID,
+		"format":    "json",
+	})
+	if extractDataMap(t, jsonExport)["filters"] == nil {
+		t.Fatalf("JSON export did not include filters: %#v", jsonExport)
+	}
+
+	pdfExport := h.callOK(ctx, "clockify_export_shared_report", map[string]any{
+		"report_id": reportID,
+		"format":    "pdf",
+	})
+	pdfData := extractDataMap(t, pdfExport)
+	if ct, _ := pdfData["contentType"].(string); ct != "application/pdf" {
+		t.Fatalf("PDF export content type mismatch: got %q data=%#v", ct, pdfData)
+	}
+	if bytes, _ := pdfData["bytes"].(float64); bytes <= 0 {
+		t.Fatalf("PDF export returned no bytes: %#v", pdfData)
+	}
+
+	list := h.callOK(ctx, "clockify_list_shared_reports", map[string]any{"page": 1, "page_size": 100})
+	seenTypes := map[string]string{"SUMMARY": reportID}
+	for _, row := range extractList(t, list) {
+		obj, ok := row.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := obj["type"].(string)
+		id, _ := obj["id"].(string)
+		if id != "" && (typ == "DETAILED" || typ == "WEEKLY") {
+			if _, exists := seenTypes[typ]; !exists {
+				seenTypes[typ] = id
+			}
+		}
+	}
+	for _, typ := range []string{"SUMMARY", "DETAILED", "WEEKLY"} {
+		id := seenTypes[typ]
+		if id == "" {
+			t.Logf("no %s shared report available to export in sacrificial workspace", typ)
+			continue
+		}
+		result := h.callOK(ctx, "clockify_export_shared_report", map[string]any{
+			"report_id": id,
+			"format":    "json",
+		})
+		data := extractDataMap(t, result)
+		if data["filters"] == nil {
+			t.Fatalf("%s shared report JSON export missing filters: %#v", typ, data)
+		}
+	}
+
+	_ = h.callOK(ctx, "clockify_delete_shared_report", map[string]any{
+		"report_id": reportID,
+		"dry_run":   true,
+	})
+	_ = h.callOK(ctx, "clockify_delete_shared_report", map[string]any{"report_id": reportID})
+	reportDeleted = true
+}

--- a/tests/e2e_live_t2_time_off_approvals_test.go
+++ b/tests/e2e_live_t2_time_off_approvals_test.go
@@ -1,0 +1,293 @@
+//go:build livee2e
+
+package e2e_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apet97/go-clockify/internal/policy"
+)
+
+func TestLiveT2TimeOffRemainingTools(t *testing.T) {
+	requireCategory(t, "CLOCKIFY_LIVE_FULL_SURFACE_ENABLED")
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Full})
+	c := setupLiveCampaign(t, h)
+	c.activateTier2("time_off")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	policies := extractList(t, h.callOK(ctx, "clockify_list_time_off_policies", map[string]any{"page": 1, "page_size": 50}))
+	if len(policies) == 0 {
+		t.Log("no time-off policies in sacrificial workspace; probing remaining tools through known error paths")
+		exerciseTimeOffRequestErrorPaths(t, h, ctx, "000000000000000000000001", "000000000000000000000002")
+		return
+	}
+	policyID := idFromRow(policies[0])
+	if policyID == "" {
+		t.Fatalf("first time-off policy has no id: %#v", policies[0])
+	}
+
+	_ = h.callOK(ctx, "clockify_get_time_off_policy", map[string]any{"policy_id": policyID})
+	if _, errText := liveCallMaybe(t, h, ctx, "clockify_time_off_balance", map[string]any{
+		"policy_id": policyID,
+		"user_id":   c.OwnerUserID,
+	}); errText != "" && !containsErrorText(errText, "balance", "not found", "permission", "plan", "400", "403", "404") {
+		t.Fatalf("unexpected clockify_time_off_balance error: %q", errText)
+	}
+
+	requestID := createLiveTimeOffRequest(t, h, c, ctx, policyID, 760, "time-off")
+	if requestID == "" {
+		exerciseTimeOffRequestErrorPaths(t, h, ctx, policyID, "000000000000000000000002")
+	} else {
+		deleted := false
+		c.RegisterCleanup("time-off-request", requestID, func(ctx context.Context) error {
+			if deleted {
+				return nil
+			}
+			return c.rawDeletePath(ctx, "/time-off/policies/"+policyID+"/requests/"+requestID)
+		})
+
+		if _, errText := liveCallMaybe(t, h, ctx, "clockify_get_time_off_request", map[string]any{
+			"policy_id":  policyID,
+			"request_id": requestID,
+		}); errText != "" && !containsErrorText(errText, "method", "not supported", "405", "404") {
+			t.Fatalf("unexpected clockify_get_time_off_request error: %q", errText)
+		}
+
+		_, updateErr := liveCallMaybe(t, h, ctx, "clockify_update_time_off_request", map[string]any{
+			"policy_id":  policyID,
+			"request_id": requestID,
+			"note":       c.LivePrefix("time-off-updated", 0),
+			"status":     "REJECTED",
+		})
+		if updateErr != "" && !containsErrorText(updateErr, "permission", "not found", "method", "400", "403", "404", "405") {
+			t.Fatalf("unexpected clockify_update_time_off_request error: %q", updateErr)
+		}
+
+		if _, errText := liveCallMaybe(t, h, ctx, "clockify_delete_time_off_request", map[string]any{
+			"policy_id":  policyID,
+			"request_id": requestID,
+			"dry_run":    true,
+		}); errText != "" && !containsErrorText(errText, "method", "not supported", "405", "404") {
+			t.Fatalf("unexpected dry-run delete_time_off_request error: %q", errText)
+		}
+		if _, errText := liveCallMaybe(t, h, ctx, "clockify_delete_time_off_request", map[string]any{
+			"policy_id":  policyID,
+			"request_id": requestID,
+		}); errText != "" && !containsErrorText(errText, "not found", "permission", "400", "403", "404") {
+			t.Fatalf("unexpected delete_time_off_request error: %q", errText)
+		} else if errText == "" {
+			deleted = true
+		}
+	}
+
+	for _, tc := range []struct {
+		tool string
+		day  int
+		args func(string) map[string]any
+	}{
+		{"clockify_approve_time_off", 761, func(id string) map[string]any {
+			return map[string]any{"policy_id": policyID, "request_id": id, "note": c.LivePrefix("approve", 0)}
+		}},
+		{"clockify_deny_time_off", 762, func(id string) map[string]any {
+			return map[string]any{"policy_id": policyID, "request_id": id, "note": c.LivePrefix("deny", 0)}
+		}},
+	} {
+		reqID := createLiveTimeOffRequest(t, h, c, ctx, policyID, tc.day, tc.tool)
+		if reqID == "" {
+			reqID = "000000000000000000000002"
+		}
+		if _, errText := liveCallMaybe(t, h, ctx, tc.tool, tc.args(reqID)); errText != "" &&
+			!containsErrorText(errText, "permission", "not found", "method", "400", "403", "404", "405") {
+			t.Fatalf("unexpected %s error: %q", tc.tool, errText)
+		}
+	}
+
+	createPolicyErr := h.callExpectError(ctx, "clockify_create_time_off_policy", map[string]any{
+		"name": strings.Repeat("x", 200),
+	})
+	if !containsErrorText(createPolicyErr, "length", "validation", "400", "404", "method", "not supported") {
+		t.Fatalf("unexpected create_time_off_policy validation error: %q", createPolicyErr)
+	}
+	updatePolicyErr := h.callExpectError(ctx, "clockify_update_time_off_policy", map[string]any{
+		"policy_id": "000000000000000000000001",
+		"name":      "mcp-live-policy",
+	})
+	if !containsErrorText(updatePolicyErr, "not found", "doesn't belong", "400", "404", "method", "not supported") {
+		t.Fatalf("unexpected update_time_off_policy error: %q", updatePolicyErr)
+	}
+}
+
+func TestLiveT2ApprovalsRemainingTools(t *testing.T) {
+	requireCategory(t, "CLOCKIFY_LIVE_FULL_SURFACE_ENABLED")
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Full})
+	c := setupLiveCampaign(t, h)
+	c.activateTier2("approvals")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	approvalID := ""
+	for _, row := range extractList(t, h.callOK(ctx, "clockify_list_approval_requests", map[string]any{"page": 1, "page_size": 25})) {
+		if id := approvalIDFromRow(row); id != "" {
+			approvalID = id
+			break
+		}
+	}
+
+	submit := map[string]any{
+		"period":       "WEEKLY",
+		"period_start": startOfWeek(time.Now().UTC()).Format("2006-01-02T15:04:05.000Z"),
+	}
+	if result, errText := liveCallMaybe(t, h, ctx, "clockify_submit_for_approval", submit); errText != "" {
+		if !containsErrorText(errText, "approval", "period", "permission", "plan", "already", "400", "403", "409") {
+			t.Fatalf("unexpected submit_for_approval error: %q", errText)
+		}
+	} else if id := approvalIDFromResult(result); id != "" {
+		approvalID = id
+	}
+
+	if approvalID == "" {
+		approvalID = "000000000000000000000001"
+	}
+	if _, errText := liveCallMaybe(t, h, ctx, "clockify_get_approval_request", map[string]any{
+		"approval_id": approvalID,
+	}); errText != "" && !containsErrorText(errText, "not found", "doesn't belong", "method", "not supported", "400", "404", "405") {
+		t.Fatalf("unexpected get_approval_request error: %q", errText)
+	}
+
+	for _, tc := range []struct {
+		tool string
+		args map[string]any
+	}{
+		{"clockify_approve_timesheet", map[string]any{"approval_id": approvalID, "dry_run": true}},
+		{"clockify_reject_timesheet", map[string]any{"approval_id": approvalID, "reason": c.LivePrefix("reject", 0), "dry_run": true}},
+		{"clockify_withdraw_approval", map[string]any{"approval_id": approvalID}},
+	} {
+		if _, errText := liveCallMaybe(t, h, ctx, tc.tool, tc.args); errText != "" &&
+			!containsErrorText(errText, "not found", "doesn't belong", "permission", "status", "400", "403", "404", "405") {
+			t.Fatalf("unexpected %s error: %q", tc.tool, errText)
+		}
+	}
+}
+
+func createLiveTimeOffRequest(t *testing.T, h *liveMCPHarness, c *liveCampaignContext, ctx context.Context, policyID string, dayOffset int, noteSuffix string) string {
+	t.Helper()
+	day := time.Now().UTC().AddDate(2, 0, dayOffset).Format("2006-01-02")
+	result, errText := liveCallMaybe(t, h, ctx, "clockify_create_time_off_request", map[string]any{
+		"policy_id": policyID,
+		"start":     day,
+		"end":       day,
+		"note":      c.LivePrefix(noteSuffix, 0),
+	})
+	if errText != "" {
+		if !containsErrorText(errText, "time off", "balance", "policy", "permission", "plan", "already", "400", "403", "404", "409") {
+			t.Fatalf("unexpected create_time_off_request error: %q", errText)
+		}
+		t.Logf("clockify_create_time_off_request unavailable for %s: %s", noteSuffix, errText)
+		return ""
+	}
+	id, _ := extractDataMap(t, result)["id"].(string)
+	if id == "" {
+		t.Fatalf("clockify_create_time_off_request returned no id: %#v", result)
+	}
+	return id
+}
+
+func exerciseTimeOffRequestErrorPaths(t *testing.T, h *liveMCPHarness, ctx context.Context, policyID, requestID string) {
+	t.Helper()
+	for _, tc := range []struct {
+		tool string
+		args map[string]any
+	}{
+		{"clockify_get_time_off_policy", map[string]any{"policy_id": policyID}},
+		{"clockify_get_time_off_request", map[string]any{"policy_id": policyID, "request_id": requestID}},
+		{"clockify_update_time_off_request", map[string]any{"policy_id": policyID, "request_id": requestID, "note": "x", "status": "REJECTED"}},
+		{"clockify_delete_time_off_request", map[string]any{"policy_id": policyID, "request_id": requestID}},
+		{"clockify_approve_time_off", map[string]any{"policy_id": policyID, "request_id": requestID}},
+		{"clockify_deny_time_off", map[string]any{"policy_id": policyID, "request_id": requestID}},
+		{"clockify_time_off_balance", map[string]any{"policy_id": policyID, "user_id": "000000000000000000000003"}},
+	} {
+		if _, errText := liveCallMaybe(t, h, ctx, tc.tool, tc.args); errText != "" &&
+			!containsErrorText(errText, "not found", "doesn't belong", "method", "permission", "400", "403", "404", "405") {
+			t.Fatalf("unexpected %s error: %q", tc.tool, errText)
+		}
+	}
+}
+
+func liveCallMaybe(t *testing.T, h *liveMCPHarness, ctx context.Context, tool string, args map[string]any) (map[string]any, string) {
+	t.Helper()
+	resp, err := h.rawCall(ctx, tool, args)
+	if err != nil {
+		t.Fatalf("rawCall %s: %v", tool, err)
+	}
+	if resp.Error != nil {
+		return nil, resp.Error.Message
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("tool %s result was not a map: %T", tool, resp.Result)
+	}
+	if isErr, _ := result["isError"].(bool); isErr {
+		content, _ := result["content"].([]any)
+		var b strings.Builder
+		for _, item := range content {
+			if entry, ok := item.(map[string]any); ok {
+				if text, ok := entry["text"].(string); ok {
+					b.WriteString(text)
+				}
+			}
+		}
+		return nil, b.String()
+	}
+	return result, ""
+}
+
+func idFromRow(row any) string {
+	obj, ok := row.(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := obj["id"].(string)
+	return id
+}
+
+func approvalIDFromRow(row any) string {
+	obj, ok := row.(map[string]any)
+	if !ok {
+		return ""
+	}
+	if id, _ := obj["id"].(string); id != "" {
+		return id
+	}
+	if nested, ok := obj["approvalRequest"].(map[string]any); ok {
+		id, _ := nested["id"].(string)
+		return id
+	}
+	return ""
+}
+
+func approvalIDFromResult(result map[string]any) string {
+	sc, _ := result["structuredContent"].(map[string]any)
+	if data, ok := sc["data"].(map[string]any); ok {
+		if id, _ := data["id"].(string); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func startOfWeek(t time.Time) time.Time {
+	weekday := int(t.Weekday())
+	if weekday == 0 {
+		weekday = 7
+	}
+	start := t.AddDate(0, 0, -(weekday - 1))
+	return time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/tests/e2e_live_t2_user_admin_test.go
+++ b/tests/e2e_live_t2_user_admin_test.go
@@ -1,0 +1,94 @@
+//go:build livee2e
+
+package e2e_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apet97/go-clockify/internal/policy"
+)
+
+func TestLiveT2UserAdminCRUDAndOwnerSafety(t *testing.T) {
+	requireCategory(t, "CLOCKIFY_LIVE_ADMIN_ENABLED")
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Full})
+	c := setupLiveCampaign(t, h)
+	c.activateTier2("user_admin")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	created := h.callOK(ctx, "clockify_create_user_group", map[string]any{
+		"name": c.LivePrefix("ua", 0),
+	})
+	groupID, _ := extractDataMap(t, created)["id"].(string)
+	if groupID == "" {
+		t.Fatalf("clockify_create_user_group returned no id: %#v", created)
+	}
+	groupDeleted := false
+	c.RegisterCleanup("user-admin-group", groupID, func(ctx context.Context) error {
+		if groupDeleted {
+			return nil
+		}
+		return c.rawDeletePath(ctx, "/user-groups/"+groupID)
+	})
+
+	updated := h.callOK(ctx, "clockify_update_user_group", map[string]any{
+		"group_id": groupID,
+		"name":     c.LivePrefix("ua-renamed", 0),
+	})
+	if gotID, _ := extractDataMap(t, updated)["id"].(string); gotID != groupID {
+		t.Fatalf("clockify_update_user_group id mismatch: got %q want %q", gotID, groupID)
+	}
+
+	_ = h.callOK(ctx, "clockify_add_user_to_group", map[string]any{
+		"group_id": groupID,
+		"user_id":  c.OwnerUserID,
+	})
+
+	_ = h.callOK(ctx, "clockify_remove_user_from_group", map[string]any{
+		"group_id": groupID,
+		"user_id":  c.OwnerUserID,
+		"dry_run":  true,
+	})
+	_ = h.callOK(ctx, "clockify_remove_user_from_group", map[string]any{
+		"group_id": groupID,
+		"user_id":  c.OwnerUserID,
+	})
+
+	roleErr := h.callExpectError(ctx, "clockify_update_user_role", map[string]any{
+		"user_id": "000000000000000000000001",
+		"role":    "REGULAR",
+	})
+	if !containsErrorText(roleErr, "not found", "doesn't belong", "404", "400", "405", "method not allowed", "permission") {
+		t.Fatalf("expected not-found/permission/method-style update_user_role error, got %q", roleErr)
+	}
+
+	dryDeactivate := h.callOK(ctx, "clockify_deactivate_user", map[string]any{
+		"user_id": c.OwnerUserID,
+		"dry_run": true,
+	})
+	if dryRun, _ := extractDataMap(t, dryDeactivate)["dry_run"].(bool); !dryRun {
+		t.Fatalf("clockify_deactivate_user dry-run did not return dry_run=true: %#v", dryDeactivate)
+	}
+
+	_ = h.callOK(ctx, "clockify_delete_user_group", map[string]any{
+		"group_id": groupID,
+		"dry_run":  true,
+	})
+	_ = h.callOK(ctx, "clockify_delete_user_group", map[string]any{"group_id": groupID})
+	groupDeleted = true
+}
+
+func containsErrorText(s string, needles ...string) bool {
+	lower := strings.ToLower(s)
+	for _, needle := range needles {
+		if strings.Contains(lower, strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e_live_t2_webhooks_test.go
+++ b/tests/e2e_live_t2_webhooks_test.go
@@ -1,0 +1,76 @@
+//go:build livee2e
+
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apet97/go-clockify/internal/policy"
+)
+
+func TestLiveT2WebhooksCRUD(t *testing.T) {
+	requireCategory(t, "CLOCKIFY_LIVE_FULL_SURFACE_ENABLED")
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Full})
+	c := setupLiveCampaign(t, h)
+	c.activateTier2("webhooks")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	create := h.callOK(ctx, "clockify_create_webhook", map[string]any{
+		"name":                "mcp-live-wh",
+		"url":                 "https://example.com/clockify-mcp-live",
+		"webhook_event":       "NEW_TIME_ENTRY",
+		"trigger_source_type": "WORKSPACE_ID",
+		"trigger_source":      []any{c.WorkspaceID},
+	})
+	webhookID, _ := extractDataMap(t, create)["id"].(string)
+	if webhookID == "" {
+		t.Fatalf("clockify_create_webhook returned no id: %#v", create)
+	}
+	webhookDeleted := false
+	c.RegisterCleanup("webhook", webhookID, func(ctx context.Context) error {
+		if webhookDeleted {
+			return nil
+		}
+		return c.rawDeletePath(ctx, "/webhooks/"+webhookID)
+	})
+
+	got := h.callOK(ctx, "clockify_get_webhook", map[string]any{"webhook_id": webhookID})
+	gotData := extractDataMap(t, got)
+	if gotID, _ := gotData["id"].(string); gotID != webhookID {
+		t.Fatalf("clockify_get_webhook id mismatch: got %q want %q", gotID, webhookID)
+	}
+	if event, _ := gotData["webhookEvent"].(string); event != "NEW_TIME_ENTRY" {
+		t.Fatalf("clockify_get_webhook event mismatch: got %q data=%#v", event, gotData)
+	}
+
+	updated := h.callOK(ctx, "clockify_update_webhook", map[string]any{
+		"webhook_id":    webhookID,
+		"name":          "mcp-live-wh2",
+		"webhook_event": "TIMER_STOPPED",
+	})
+	if event, _ := extractDataMap(t, updated)["webhookEvent"].(string); event != "TIMER_STOPPED" {
+		t.Fatalf("clockify_update_webhook did not update event: %#v", updated)
+	}
+
+	events := extractList(t, h.callOK(ctx, "clockify_list_webhook_events", nil))
+	if len(events) < 2 {
+		t.Fatalf("clockify_list_webhook_events returned too few events: %#v", events)
+	}
+
+	_ = h.callOK(ctx, "clockify_test_webhook", map[string]any{
+		"webhook_id": webhookID,
+		"dry_run":    true,
+	})
+
+	_ = h.callOK(ctx, "clockify_delete_webhook", map[string]any{
+		"webhook_id": webhookID,
+		"dry_run":    true,
+	})
+	_ = h.callOK(ctx, "clockify_delete_webhook", map[string]any{"webhook_id": webhookID})
+	webhookDeleted = true
+}

--- a/tests/e2e_live_tier1_remaining_crud_test.go
+++ b/tests/e2e_live_tier1_remaining_crud_test.go
@@ -1,0 +1,143 @@
+//go:build livee2e
+
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apet97/go-clockify/internal/policy"
+)
+
+// TestLiveTier1RemainingCRUD covers Tier-1 MCP tools that were not part
+// of the original live campaign. Every mutating call creates only
+// prefix-owned sacrificial entities and registers raw cleanup.
+func TestLiveTier1RemainingCRUD(t *testing.T) {
+	requireWriteEnabled(t)
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Standard})
+	c := setupLiveCampaign(t, h)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	projectName := c.LivePrefix("tier1-proj", 0)
+	project := h.callOK(ctx, "clockify_create_project", map[string]any{"name": projectName})
+	projectID, _ := extractDataMap(t, project)["id"].(string)
+	if projectID == "" {
+		t.Fatalf("clockify_create_project returned no id: %#v", project)
+	}
+	c.RegisterCleanup("project", projectID, func(ctx context.Context) error {
+		return c.rawArchiveAndDeleteProject(ctx, projectID)
+	})
+
+	t.Run("read_remaining_lists_and_getters", func(t *testing.T) {
+		_ = h.callOK(ctx, "clockify_get_project", map[string]any{"project": projectID})
+		_ = h.callOK(ctx, "clockify_list_clients", map[string]any{"page": 1, "page_size": 5})
+		_ = h.callOK(ctx, "clockify_list_entries", map[string]any{
+			"start":     time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339),
+			"end":       time.Now().UTC().AddDate(0, 0, 1).Format(time.RFC3339),
+			"page_size": 10,
+		})
+		_ = h.callOK(ctx, "clockify_search_tools", map[string]any{"query": "project"})
+	})
+
+	t.Run("create_task", func(t *testing.T) {
+		result := h.callOK(ctx, "clockify_create_task", map[string]any{
+			"project": projectID,
+			"name":    c.LivePrefix("task", 0),
+		})
+		if id, _ := extractDataMap(t, result)["id"].(string); id == "" {
+			t.Fatalf("clockify_create_task returned no id: %#v", result)
+		}
+	})
+
+	start := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Second)
+	entryStart := start.Format(time.RFC3339)
+	entryEnd := start.Add(30 * time.Minute).Format(time.RFC3339)
+
+	t.Run("log_update_find_and_update_entry", func(t *testing.T) {
+		result := h.callOK(ctx, "clockify_log_time", map[string]any{
+			"project_id":  projectID,
+			"description": c.LivePrefix("log", 0),
+			"start":       entryStart,
+			"end":         entryEnd,
+			"billable":    false,
+		})
+		entryID := liveEntryIDFromResult(t, result)
+		c.RegisterCleanup("entry", entryID, func(ctx context.Context) error {
+			return h.deleteEntryRaw(ctx, entryID)
+		})
+
+		update := h.callOK(ctx, "clockify_update_entry", map[string]any{
+			"entry_id":    entryID,
+			"description": c.LivePrefix("update", 0),
+			"billable":    true,
+		})
+		if got := liveEntryIDFromResult(t, update); got != entryID {
+			t.Fatalf("clockify_update_entry id mismatch: got %q want %q", got, entryID)
+		}
+
+		find := h.callOK(ctx, "clockify_find_and_update_entry", map[string]any{
+			"entry_id":        entryID,
+			"new_description": c.LivePrefix("find-update", 0),
+			"billable":        false,
+		})
+		if got := liveEntryIDFromResult(t, find); got != entryID {
+			t.Fatalf("clockify_find_and_update_entry id mismatch: got %q want %q", got, entryID)
+		}
+	})
+
+	t.Run("switch_project_starts_timer_then_stop_cleanup", func(t *testing.T) {
+		result := h.callOK(ctx, "clockify_switch_project", map[string]any{
+			"project":     projectID,
+			"description": c.LivePrefix("switch", 0),
+		})
+		startedID := liveNestedEntryID(t, result, "started")
+		if startedID == "" {
+			t.Fatalf("clockify_switch_project did not expose started entry id: %#v", result)
+		}
+		c.RegisterCleanup("entry", startedID, func(ctx context.Context) error {
+			return h.deleteEntryRaw(ctx, startedID)
+		})
+
+		stopped := h.callOK(ctx, "clockify_stop_timer", nil)
+		stoppedID := liveEntryIDFromResult(t, stopped)
+		if stoppedID != startedID {
+			t.Fatalf("clockify_stop_timer id mismatch after switch: got %q want %q", stoppedID, startedID)
+		}
+	})
+}
+
+func liveEntryIDFromResult(t *testing.T, result map[string]any) string {
+	t.Helper()
+	data := extractDataMap(t, result)
+	if id, _ := data["id"].(string); id != "" {
+		return id
+	}
+	if entry, ok := data["entry"].(map[string]any); ok {
+		if id, _ := entry["id"].(string); id != "" {
+			return id
+		}
+	}
+	t.Fatalf("result did not contain an entry id: %#v", result)
+	return ""
+}
+
+func liveNestedEntryID(t *testing.T, result map[string]any, field string) string {
+	t.Helper()
+	data := extractDataMap(t, result)
+	nested, ok := data[field].(map[string]any)
+	if !ok {
+		return ""
+	}
+	if id, _ := nested["id"].(string); id != "" {
+		return id
+	}
+	if entry, ok := nested["entry"].(map[string]any); ok {
+		id, _ := entry["id"].(string)
+		return id
+	}
+	return ""
+}


### PR DESCRIPTION
Summary:
- add sacrificial-workspace live probes so every 121-tool catalog name is exercised through MCP
- fix live API contract drift for invoices, expenses, webhooks, time-off requests, and approval submits
- document unsupported/permission-gated upstream routes and refresh the generated tool catalog

Verified:
- set -a; . /tmp/clockify-livetest.env; set +a; env GOCACHE=/private/tmp/go-clockify-go-build go test -tags=livee2e -count=1 -timeout 10m ./tests/...
- env GOCACHE=/private/tmp/go-clockify-go-build go test -count=1 ./internal/tools -run 'TestTier2_Invoices|TestTier2Dispatch_Invoices|TestRiskOverrides'\n- env GOCACHE=/private/tmp/go-clockify-go-build make catalog-drift\n- env GOCACHE=/private/tmp/go-clockify-go-build make doc-parity\n- env GOCACHE=/private/tmp/go-clockify-go-build make config-doc-parity\n- git diff --check\n- env GOCACHE=/private/tmp/go-clockify-go-build make check\n- env GOCACHE=/private/tmp/go-clockify-go-build make release-check