### PR TITLE
docs(launch): refresh post-PR59 coverage wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,9 @@ Clockify launch candidate** promotion.
    live-contract nightly works and how the **sacrificial
    workspace** is wired. Read this before any live Clockify call.
 6. [`docs/claude-code-continuation.md`](docs/claude-code-continuation.md)
-   — exact continuation packet for Claude Code after PR #51 merged.
+   — historical continuation packet for Claude Code after PR #51
+   merged. Use `docs/agent-handoff.md` for the current post-PR #59
+   state.
 
 If a contributor maintains a workstation-private `CLAUDE.md` at the
 repo root, it is gitignored and machine-specific; treat it as
@@ -42,6 +44,10 @@ rules live in this file and the docs above.
 
 ## Launch-state baseline
 
+- **Current post-PR #59 main tip:** `b31fd8a9af794bad7a80c50dc272ea1b74bfcc41`
+  (`test(livee2e): cover exhaustive Clockify tool surface`). This
+  is the latest pushed launch-state baseline for the 121-tool
+  manual live-probe coverage.
 - **PR #51 merge tip:** `adce316d60644fe51365086aba186227c9ae3977`
   (`docs(launch): record bench comparison evidence`), the
   launch-state baseline after PR #51 merged on 2026-05-02. If this
@@ -79,6 +85,12 @@ rules live in this file and the docs above.
     benchmark baseline was refreshed from Actions artifact
     `bench-current-25255062599` and passed normal comparison in
     Bench workflow run 25255216987.
+  - **Manual API coverage expansion.** PR #59 live-probed all 121
+    generated catalog tools through the MCP path against the
+    sacrificial workspace and documented the success-vs-unsupported
+    outcome split in [`docs/api-coverage.md`](docs/api-coverage.md).
+    This is coverage evidence only; it does **not** close Group 1,
+    Group 6, or Group 7 launch blockers.
 - **Read-side schema diff** (`tests/e2e_live_schema_test.go::TestLiveReadSideSchemaDiff`)
   is wired into the read-only step of
   `.github/workflows/live-contract.yml`. It needs scheduled-cron

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surfaced by the same probe lab pass (invoice `unitPrice`, expense
   `amount`/`total`, expense `projectId` optional-vs-required,
   shared-reports non-`SUMMARY` filter requirements) are now
-  documented in `docs/api-coverage.md` under "Known unresolved
-  API contract questions" rather than carried as open inventory
-  items.
+  documented in `docs/api-coverage.md` under "Known API contract
+  notes" rather than carried as open inventory items.
 
 ### Changed
+
+- **Exhaustive manual live-probe coverage now spans the full tool
+  catalog.** PR #59 added sacrificial-workspace MCP-path probes so
+  all 121 generated catalog tools are named in `tests/e2e_live*.go`,
+  while keeping the nightly `live-contract.yml` regex narrow for
+  blast-radius control. The docs now separate full success paths
+  from unsupported, permission-gated, plan-gated, or workspace-state
+  limited outcomes; the manual probes do not close Group 1, Group 6,
+  or Group 7 launch-candidate evidence.
 
 - **Live read-side schema drift is now a first-class contract.**
   Added `tests/e2e_live_schema_test.go::TestLiveReadSideSchemaDiff`,

--- a/README.md
+++ b/README.md
@@ -343,9 +343,11 @@ For a single-page operator overview that links the threat model, transports, aut
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Autonomous agents should start with [AGENTS.md](AGENTS.md). For the
-current launch-candidate continuation state after PR #51, use
-[docs/claude-code-continuation.md](docs/claude-code-continuation.md).
+Autonomous agents should start with [AGENTS.md](AGENTS.md) and the
+current launch-state handoff in
+[docs/agent-handoff.md](docs/agent-handoff.md). The
+[Claude Code continuation packet](docs/claude-code-continuation.md)
+is retained as the historical post-PR #51 handoff.
 
 ## Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,8 +107,10 @@ Supply-chain verification, release process, and the smoke cadence.
 What this project promises, and how the one-of-one maintainer
 population is reflected across policy surfaces.
 
+- [agent-handoff.md](agent-handoff.md) — current autonomous-agent
+  launch-state entry point.
 - [claude-code-continuation.md](claude-code-continuation.md) —
-  exact Claude Code continuation packet for the post-PR #51
+  historical Claude Code continuation packet for the post-PR #51
   launch-candidate evidence pass.
 - [../GOVERNANCE.md](../GOVERNANCE.md) — merge gate, sensitive-area
   self-review expectations, security disclosure process.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -14,6 +14,10 @@ work and commit it.
 
 ## Launch-state baseline
 
+- **Current post-PR #59 main tip:** `b31fd8a9af794bad7a80c50dc272ea1b74bfcc41`
+  (`test(livee2e): cover exhaustive Clockify tool surface`). This
+  is the latest pushed launch-state baseline for the 121-tool
+  manual live-probe coverage.
 - **PR #51 merge tip:** `adce316d60644fe51365086aba186227c9ae3977`
   (`docs(launch): record bench comparison evidence`) — the
   launch-state baseline after PR #51 merged on 2026-05-02. If this
@@ -26,8 +30,11 @@ work and commit it.
   `forward_auth` cardinality/size guard), 5 (per-profile "How to
   verify this deployment" sections, client matrix, support matrix),
   false-green live-contract prevention, launch-evidence parity gate,
-  and benchmark baseline refresh (`bench-current-25255062599` +
-  comparison run 25255216987).
+  benchmark baseline refresh (`bench-current-25255062599` +
+  comparison run 25255216987), and PR #59's exhaustive manual
+  sacrificial-workspace probe across all 121 generated catalog
+  tools. The PR #59 probes are coverage evidence only and do not
+  tick any external launch-evidence box.
 - **Open external evidence only:**
   - **Scheduled live-contract cron greens** — two consecutive
     *scheduled* runs of `live-contract.yml` on the candidate SHA,
@@ -79,8 +86,8 @@ wraps the test run with evidence warnings.
    — the deployment shape that the launch candidate is built
    around.
 7. [`claude-code-continuation.md`](claude-code-continuation.md) —
-   exact Claude Code continuation packet with prompts, branch
-   rules, and verification sequence.
+   historical Claude Code continuation packet with prompts, branch
+   rules, and verification sequence from the post-PR #51 state.
 
 ## Current known blockers
 

--- a/docs/claude-code-continuation.md
+++ b/docs/claude-code-continuation.md
@@ -2,6 +2,11 @@
 
 Prepared 2026-05-02 after PR #51 merged into `main`.
 
+> Historical note: this packet records the handoff state immediately
+> after PR #51. The current autonomous-agent entry point is
+> [`docs/agent-handoff.md`](agent-handoff.md), which includes the
+> post-PR #59 exhaustive manual live-probe coverage.
+
 ## Current State
 
 - **Branch to start from:** `main`

--- a/docs/live-campaign-next.md
+++ b/docs/live-campaign-next.md
@@ -66,7 +66,7 @@ as a record of what got found, not as a current task list — the
 task list is in `docs/launch-candidate-checklist.md` and
 `docs/api-coverage.md`.
 
-Follow-up branch `test/exhaustive-live-coverage-followup` extends the
+Merged PR #59 (`test/exhaustive-live-coverage-followup`) extends the
 manual sacrificial-workspace suite so every one of the 121 generated
 catalog tools is named in `tests/e2e_live*.go` and exercised through
 the MCP path. New coverage includes the remaining Tier-1 CRUD/logging
@@ -205,7 +205,11 @@ coverage status.
     `{TXT, NUMBER, DROPDOWN_SINGLE, DROPDOWN_MULTIPLE, CHECKBOX,
     LINK}`. Closed by advertising the live enum values.
 
-## Tests that currently pass (success path, against the sacrificial workspace)
+## Tests that currently pass or pin expected live outcomes
+
+The list below includes both full success paths and mixed probes that
+pass by asserting a concrete upstream constraint. Do not read it as a
+claim that every tool has a successful CRUD path.
 
 Run: `go test -tags=livee2e -count=1 -timeout 10m ./tests/...`
 (with the env file sourced — see below). Wall-clock 18.4 s.

--- a/docs/live-campaign-next.md
+++ b/docs/live-campaign-next.md
@@ -1,9 +1,9 @@
 # Live-Validation Campaign — Continuation Handoff
 
 Date: 2026-05-02 (status note added 2026-05-03)
-Branch: `test/full-live-workspace-validation` (12 commits ahead of `main`,
-pushed to `origin`)
-Draft PR: https://github.com/apet97/go-clockify/pull/53
+Historical branch: `test/full-live-workspace-validation` (12 commits,
+superseded by merged PRs #53-#59)
+Historical draft PR: https://github.com/apet97/go-clockify/pull/53
 
 This doc tells the next agent (or maintainer) exactly what state the
 live-validation campaign is in, what tests pass, what bugs were

--- a/docs/live-tests.md
+++ b/docs/live-tests.md
@@ -8,12 +8,16 @@ changes break customer integrations without anyone noticing.
 
 ## Current launch-candidate evidence status
 
-As of 2026-05-02 after PR #51 merged to `main` at
-`adce316d60644fe51365086aba186227c9ae3977`, local live-contract
-false-green prevention is in place, but Group 1 is still open. Two
-manual-dispatch runs are green (read-only 25238997088, full-tier
-25239216412); only two consecutive scheduled cron greens on the
-candidate SHA count as launch-candidate evidence.
+As of 2026-05-03 after PR #59 merged to `main` at
+`b31fd8a9af794bad7a80c50dc272ea1b74bfcc41`, local live-contract
+false-green prevention is in place and all 121 generated catalog
+tools have manual sacrificial-workspace MCP-path probes. Group 1 is
+still open: two manual-dispatch runs are green (read-only
+25238997088, full-tier 25239216412), but only two consecutive
+scheduled cron greens on the candidate SHA count as
+launch-candidate evidence. The exhaustive PR #59 probes are
+manual/local coverage artifacts and are intentionally not part of
+the nightly `live-contract.yml` regex.
 
 ## What runs
 

--- a/docs/official-clockify-mcp-gap-analysis.md
+++ b/docs/official-clockify-mcp-gap-analysis.md
@@ -2,7 +2,8 @@
 
 A snapshot of where `clockify-mcp` sits on the path from
 "community-grade MCP server" to "officially-supported Clockify
-product." Written 2026-05-02, intended to be updated as gaps close.
+product." Written 2026-05-02; last updated 2026-05-03 after
+PR #59's exhaustive manual live-probe follow-up.
 
 This document is **not** a roadmap and **not** a checklist. It is a
 narrative reading of the current state. The bound checklist lives
@@ -249,13 +250,18 @@ What is missing for tier 3 is intentionally narrow:
 - **API coverage matrix.** [`docs/api-coverage.md`](api-coverage.md)
   maps all 121 MCP tools to their Clockify API endpoints, classifies
   each tool by read-only/mutating/destructive/billing/admin risk, and
-  lists the current unit/integration/live-test coverage per tool.
-  Gaps are explicit — dry-run coverage (6/14 destructive tools wired,
-  1/14 live-tested), policy-mode live coverage (2/5 modes),
-  schema-drift scope (read-side only), and Tier 2 live coverage
-  (success-path: 0/88 tools cron-pinned). The evidence hierarchy (scheduled workflow >
-  manual dispatch > local with env vars > local without env vars as
-  non-evidence) is documented there.
+  lists the current unit/integration/live-test coverage per tool. PR
+  #59 extended the manual sacrificial-workspace suite so every catalog
+  tool name is live-probed through the MCP path. The matrix separates
+  full success paths from explicit upstream constraints such as
+  unsupported 405 routes, permission/plan gates, and workspace-state
+  caps. Remaining gaps are also explicit: mutating request-schema drift
+  is not automated, the exhaustive probes are not cron launch evidence,
+  and some destructive tools can only assert a minimal dry-run envelope
+  or upstream 4xx because Clockify exposes no safe preview route. The
+  evidence hierarchy (scheduled workflow > manual dispatch > local
+  with env vars > local without env vars as non-evidence) is documented
+  there.
 - **Benchmark baseline is current for the candidate shape.** The
   committed `internal/benchdata/baseline.txt` was refreshed from the
   `Bench` workflow bootstrap artifact `bench-current-25255062599`
@@ -273,10 +279,10 @@ What is missing for tier 3 is intentionally narrow:
 In priority order — closing the lower-numbered ones first
 unblocks the next.
 
-Only external evidence blockers remain after PR #51 merged to `main` at
-`adce316d60644fe51365086aba186227c9ae3977`: scheduled live-contract
-cron greens, candidate-tag security walk-through evidence, and
-release/sigstore/SLSA evidence.
+Only external evidence blockers remain after PR #59 merged to `main`
+at `b31fd8a9af794bad7a80c50dc272ea1b74bfcc41`: scheduled
+live-contract cron greens, candidate-tag security walk-through
+evidence, and release/sigstore/SLSA evidence.
 
 1. **Live contract failures (current).**
    *Where:* `.github/workflows/live-contract.yml` and the rolling

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -39,13 +39,18 @@ The blessed production profile for shared services is documented in [Production 
 ## Launch-candidate status
 
 `main` is locally prepared for the official Clockify launch-candidate
-evidence pass as of PR #51 (`adce316d60644fe51365086aba186227c9ae3977`).
-The remaining blockers are external evidence only: two consecutive
-scheduled live-contract cron greens, candidate-tag security
-walk-through evidence, and release/sigstore/SLSA evidence. Local
-`release-check` and PR CI greens are necessary but not sufficient for
-an official launch-ready claim. Agent continuation details live in
-[`docs/claude-code-continuation.md`](claude-code-continuation.md).
+evidence pass as of PR #59
+(`b31fd8a9af794bad7a80c50dc272ea1b74bfcc41`). That includes the
+post-PR #51 local readiness gates plus manual sacrificial-workspace
+MCP-path probes for all 121 generated catalog tools. The remaining
+blockers are external evidence only: two consecutive scheduled
+live-contract cron greens, candidate-tag security walk-through
+evidence, and release/sigstore/SLSA evidence. Local `release-check`,
+PR CI greens, and manual exhaustive live probes are necessary context
+but not sufficient for an official launch-ready claim. Agent
+continuation details live in [`docs/agent-handoff.md`](agent-handoff.md);
+[`docs/claude-code-continuation.md`](claude-code-continuation.md) is
+the historical PR #51 packet.
 
 ## Pick an auth mode (HTTP / gRPC transports only)
 


### PR DESCRIPTION
Summary:
- refresh official gap-analysis wording after PR #59 exhaustive manual live probes
- clarify that mixed live-campaign tests pass by asserting expected upstream constraints, not universal success paths
- keep Groups 1, 6, and 7 explicitly external-evidence blockers

Audit findings:
- docs/api-coverage.md already reports 121 catalog tools and separates manual live probes from scheduled launch evidence
- docs/live-validation-campaign.md is not present; docs/live-campaign-next.md is the relevant campaign note
- no live or destructive tests were run

Verified:
- make check
- make doc-parity
- make config-doc-parity
- make catalog-drift
- make launch-checklist-parity
- git diff --check