### PR TITLE
test(livee2e): pin user invite validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Sacrificial live campaign now includes the invite-user route
+  safely.** Added `TestLiveT2UserInviteValidationProbe`, which
+  probes Clockify's documented add-user endpoint with
+  `send-email=false` and an empty email so the route/validation
+  surface is covered without sending mail or creating a pending
+  workspace member. Removed stale risk overrides for non-catalog
+  user-admin tool names and added a regression guard so future risk
+  overrides must target registered descriptors.
+
 - **Release-candidate evidence runbook and automation prepare Groups
   6 and 7 without closing them.** Added
   `docs/runbooks/release-candidate-evidence.md`,

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -263,6 +263,15 @@ Clockify endpoints: `GET/POST/PUT/DELETE /workspaces/{ws}/users/*`, `/workspaces
 | `clockify_update_user_group` | mutating | `admin` | unit |
 | `clockify_update_user_role` | mutating | `admin`, `permission_change` | unit |
 
+**Invite-user route note:** Clockify documents
+`POST /workspaces/{workspaceId}/users?send-email=...` for adding a
+user to a workspace, but this MCP does not expose a
+dedicated invite-user catalog tool. The manual live campaign pins the
+route as a raw validation probe in `TestLiveT2UserInviteValidationProbe`
+with `send-email=false` and an empty email. That exercises the current
+route/plan/permission surface without sending mail or creating a
+pending workspace member.
+
 ### `webhooks` (7 tools)
 
 Clockify endpoints: `GET/POST/PUT/DELETE /workspaces/{ws}/webhooks/*`
@@ -385,6 +394,7 @@ surface and surface latent handler / upstream bugs.
 | `TestLiveT2InvoicesCRUD` | all 12 invoice tools: invoice create/list/get/update/delete, invoice report, item add/list/delete, send dry-run, mark-paid dry-run + real; update-item route asserted as unsupported on this Clockify version | success path + documented unsupported `PUT /items/{order}` 405 |
 | `TestLiveT2SharedReportsCRUDAndExports` | all 6 shared-report tools: SUMMARY create/get/update/export JSON/PDF/delete; DETAILED/WEEKLY JSON export when workspace fixtures exist | success path / conditional export breadth |
 | `TestLiveT2UserAdminCRUDAndOwnerSafety` | all 8 user-admin tools: user-group create/update/add/remove/delete, remove dry-run, deactivate owner dry-run, update-role unsupported route probe | success path + documented unsupported role route 405 |
+| `TestLiveT2UserInviteValidationProbe` | raw Clockify invite-user route `POST /workspaces/{workspaceId}/users?send-email=false`; no catalog tool exposed | validation / plan / permission / unsupported-method refusal, with no email sent |
 | `TestLiveT2WebhooksCRUD` | all 7 webhook tools: create/get/update/list-events/test dry-run/delete dry-run/delete using live `webhookEvent` + trigger-source body shape | success path |
 | `TestLiveT2TimeOffRemainingTools` | all 12 time-off tool names: policy/request list/get/create/update/delete/status/balance paths; request create reaches live body contract and unsupported/permission routes are asserted where Clockify rejects the operation | success path + plan/permission/unsupported-route probes |
 | `TestLiveT2ApprovalsRemainingTools` | all 6 approvals tool names: list, submit period/periodStart, get, approve/reject dry-run, withdraw | success path + documented approval period / GET-route 4xx probes |

--- a/docs/live-campaign-next.md
+++ b/docs/live-campaign-next.md
@@ -129,7 +129,7 @@ All gated by `//go:build livee2e` and live in `tests/`:
 | `tests/e2e_live_tier1_remaining_crud_test.go` | `TestLiveTier1RemainingCRUD` | 1 flow | remaining Tier-1 CRUD/log/search coverage |
 | `tests/e2e_live_t2_invoices_test.go` | `TestLiveT2InvoicesCRUD` | 1 flow | all invoice tools; update item pinned as unsupported 405 |
 | `tests/e2e_live_t2_shared_reports_test.go` | `TestLiveT2SharedReportsCRUDAndExports` | 1 flow | SUMMARY CRUD/export plus conditional DETAILED/WEEKLY export |
-| `tests/e2e_live_t2_user_admin_test.go` | `TestLiveT2UserAdminCRUDAndOwnerSafety` | 1 flow | user-admin group CRUD, membership add/remove, owner dry-run safety |
+| `tests/e2e_live_t2_user_admin_test.go` | `TestLiveT2UserAdminCRUDAndOwnerSafety`, `TestLiveT2UserInviteValidationProbe` | 2 flows | user-admin group CRUD, membership add/remove, owner dry-run safety; raw invite-user route validation with `send-email=false` |
 | `tests/e2e_live_t2_webhooks_test.go` | `TestLiveT2WebhooksCRUD` | 1 flow | webhook CRUD using live singular-event contract |
 | `tests/e2e_live_t2_time_off_approvals_test.go` | `TestLiveT2TimeOffRemainingTools`, `TestLiveT2ApprovalsRemainingTools` | 2 | time-off and approvals probes with success and concrete 4xx outcomes |
 
@@ -273,7 +273,11 @@ workspace-state limitations are tracked in `docs/api-coverage.md`.
     `TestLiveT2SharedReportsCRUDAndExports`.
 13. User-admin user-group CRUD, membership add/remove, owner
     deactivate dry-run, and update-role unsupported-route evidence
-    are covered by `TestLiveT2UserAdminCRUDAndOwnerSafety`.
+    are covered by `TestLiveT2UserAdminCRUDAndOwnerSafety`. The
+    documented invite-user route is pinned by
+    `TestLiveT2UserInviteValidationProbe` as a raw validation probe
+    with `send-email=false`, so the campaign covers the route without
+    sending email or creating a pending user.
 14. Webhook CRUD is covered by `TestLiveT2WebhooksCRUD`; the handler
     now uses `webhookEvent`, `triggerSourceType`, and `triggerSource`
     instead of the old plural `events` array.

--- a/internal/tools/risk_class_test.go
+++ b/internal/tools/risk_class_test.go
@@ -89,6 +89,35 @@ func TestRiskOverridesMatchTaxonomy(t *testing.T) {
 	}
 }
 
+// TestRiskOverridesTargetRegisteredTools catches ghost risk metadata for
+// tools that are not exposed in the generated catalog. User-invite style
+// endpoints are particularly easy to leave behind as planned names; keeping
+// the override map descriptor-backed prevents docs and audit review from
+// implying unsupported tools exist.
+func TestRiskOverridesTargetRegisteredTools(t *testing.T) {
+	s := &Service{}
+
+	known := map[string]bool{}
+	for _, d := range s.Registry() {
+		known[d.Tool.Name] = true
+	}
+	for groupName := range Tier2Groups {
+		ds, ok := s.Tier2Handlers(groupName)
+		if !ok {
+			t.Fatalf("Tier2Handlers(%q) returned ok=false", groupName)
+		}
+		for _, d := range ds {
+			known[d.Tool.Name] = true
+		}
+	}
+
+	for name := range riskOverrides {
+		if !known[name] {
+			t.Errorf("risk override %q has no registered tool descriptor", name)
+		}
+	}
+}
+
 // TestDefaultRiskClassFromBooleans verifies the boolean→RiskClass fallback
 // for tools that have no explicit override. A read-only tool must default
 // to RiskRead, a destructive tool to RiskDestructive, otherwise RiskWrite.

--- a/internal/tools/risk_overrides.go
+++ b/internal/tools/risk_overrides.go
@@ -60,18 +60,6 @@ var riskOverrides = map[string]riskOverride{
 		class:     mcp.RiskWrite | mcp.RiskAdmin,
 		auditKeys: []string{"user_id"},
 	},
-	"clockify_activate_user": {
-		class:     mcp.RiskWrite | mcp.RiskAdmin,
-		auditKeys: []string{"user_id"},
-	},
-	"clockify_invite_user": {
-		class:     mcp.RiskWrite | mcp.RiskAdmin | mcp.RiskExternalSideEffect,
-		auditKeys: []string{"email", "role"},
-	},
-	"clockify_remove_user_from_workspace": {
-		class:     mcp.RiskDestructive | mcp.RiskAdmin,
-		auditKeys: []string{"user_id"},
-	},
 
 	// Admin — user groups.
 	"clockify_create_user_group": {

--- a/tests/e2e_live_t2_user_admin_test.go
+++ b/tests/e2e_live_t2_user_admin_test.go
@@ -4,10 +4,12 @@ package e2e_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/apet97/go-clockify/internal/clockify"
 	"github.com/apet97/go-clockify/internal/policy"
 )
 
@@ -81,6 +83,44 @@ func TestLiveT2UserAdminCRUDAndOwnerSafety(t *testing.T) {
 	})
 	_ = h.callOK(ctx, "clockify_delete_user_group", map[string]any{"group_id": groupID})
 	groupDeleted = true
+}
+
+func TestLiveT2UserInviteValidationProbe(t *testing.T) {
+	requireCategory(t, "CLOCKIFY_LIVE_ADMIN_ENABLED")
+
+	h := setupLiveMCPHarness(t, liveMCPOptions{PolicyMode: policy.Full})
+	c := setupLiveCampaign(t, h)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var out map[string]any
+	err := h.Service.Client.Post(
+		ctx,
+		"/workspaces/"+c.WorkspaceID+"/users?send-email=false",
+		map[string]any{"email": ""},
+		&out,
+	)
+	if err == nil {
+		t.Fatalf("invite validation probe unexpectedly succeeded; refusing to risk creating an invited user: %#v", out)
+	}
+
+	var apiErr *clockify.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("invite validation probe returned non-API error: %T %v", err, err)
+	}
+	switch apiErr.StatusCode {
+	case 400, 402, 403, 405:
+		// Expected safe outcomes: request validation, plan/permission
+		// gating, or an unsupported method. The probe uses
+		// send-email=false and an empty email so none of these send
+		// mail or create a pending member.
+	default:
+		t.Fatalf("invite validation probe returned unexpected status %d: %s", apiErr.StatusCode, apiErr.Body)
+	}
+	if !containsErrorText(apiErr.Body, "email", "user", "subscription", "paid", "permission", "not supported", "method", "invalid", "required", "blank", "400", "403", "405") {
+		t.Fatalf("invite validation probe body did not identify validation/permission/plan/method refusal: %q", apiErr.Body)
+	}
 }
 
 func containsErrorText(s string, needles ...string) bool {


### PR DESCRIPTION
Summary:
- add a safe livee2e validation probe for Clockify add-user route using send-email=false and an empty email
- document that user invite is a raw route probe, not a catalog tool, and update the live campaign handoff
- remove stale risk overrides for non-catalog user invite/activation/remove-workspace tool names and add a descriptor-backed guard

Safety:
- full campaign ran against the confirmed sacrificial workspace env
- invite probe does not send email and fails if the route unexpectedly succeeds
- no launch checklist Group 1/6/7 evidence boxes were checked

Verified:
- go test -count=1 -run 'TestRiskOverrides(TargetRegisteredTools|MatchTaxonomy)|TestEveryDescriptorHasRiskClass' ./internal/tools\n- set +x; . /tmp/clockify-livetest.env; go test -tags=livee2e -count=1 -timeout 3m -run '^TestLiveT2UserInviteValidationProbe$' ./tests/...\n- set +x; . /tmp/clockify-livetest.env; go test -tags=livee2e -count=1 -timeout 10m ./tests/...\n- make check\n- make doc-parity\n- make config-doc-parity\n- make catalog-drift\n- make launch-checklist-parity\n- git diff --check