### PR TITLE
Address PR 63 follow-up findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Clockify launch candidate** promotion.
    workspace** is wired. Read this before any live Clockify call.
 6. [`docs/claude-code-continuation.md`](docs/claude-code-continuation.md)
    — historical continuation packet for Claude Code after PR #51
-   merged. Use `docs/agent-handoff.md` for the current post-PR #62
+   merged. Use `docs/agent-handoff.md` for the current post-PR #63
    launch state.
 
 If a contributor maintains a workstation-private `CLAUDE.md` at the
@@ -44,7 +44,14 @@ rules live in this file and the docs above.
 
 ## Launch-state baseline
 
-- **Current launch-state baseline:** `ff0047aa50cdcd4bb43037c72d66b218d51f13e8`
+- **Current main baseline:** `0960bfa03db143778deb59f9b9522012116c9c9b`
+  (`chore(review): harden MCP server readiness`). This records the
+  post-PR #63 local/CI remediation wave for review-found performance,
+  security, tests, stale-context, generated catalog/schema, and
+  operator/agent documentation gaps. It does **not** add live Clockify
+  evidence and does **not** close Group 1, Group 6, or Group 7 launch
+  blockers.
+- **Latest manual live-campaign baseline:** `ff0047aa50cdcd4bb43037c72d66b218d51f13e8`
   (`test(livee2e): pin user invite validation`). This records the
   full sacrificial-workspace live API campaign refresh: the documented
   invite-user route is pinned by a no-email validation probe, stale

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -14,7 +14,13 @@ work and commit it.
 
 ## Launch-state baseline
 
-- **Current launch-state baseline:** `ff0047aa50cdcd4bb43037c72d66b218d51f13e8`
+- **Current main baseline:** `0960bfa03db143778deb59f9b9522012116c9c9b`
+  (`chore(review): harden MCP server readiness`). This records the
+  post-PR #63 local/CI remediation wave for review-found performance,
+  security, tests, stale-context, generated catalog/schema, and
+  operator/agent documentation gaps. It did not run live Clockify
+  probes and does not tick any external launch-evidence box.
+- **Latest manual live-campaign baseline:** `ff0047aa50cdcd4bb43037c72d66b218d51f13e8`
   (`test(livee2e): pin user invite validation`). This records the
   manual sacrificial-workspace campaign state after PR #62: the
   PR #59 catalog snapshot (then 121 generated tools) was live-probed

--- a/docs/official-clockify-mcp-gap-analysis.md
+++ b/docs/official-clockify-mcp-gap-analysis.md
@@ -291,11 +291,13 @@ What is missing for tier 3 is intentionally narrow:
 In priority order — closing the lower-numbered ones first
 unblocks the next.
 
-Only external evidence blockers remain after PR #62 merged to `main`
-at `ff0047aa50cdcd4bb43037c72d66b218d51f13e8`: scheduled
+Only external evidence blockers remain after PR #63 merged to `main`
+at `0960bfa03db143778deb59f9b9522012116c9c9b`: scheduled
 live-contract cron greens, candidate-tag security walk-through
 evidence, and release/sigstore/SLSA evidence. The PR #59 through
-PR #62 manual live-probe work is coverage evidence only.
+PR #62 manual live-probe work remains coverage evidence only; PR #63
+was a local/CI review-remediation wave and did not add live Clockify
+evidence.
 
 1. **Scheduled live-contract cron evidence (current).**
    *Where:* `.github/workflows/live-contract.yml` and the rolling

--- a/internal/mcp/transport_streamable_http.go
+++ b/internal/mcp/transport_streamable_http.go
@@ -291,8 +291,9 @@ func streamableRPCHandler(opts StreamableHTTPOptions, mgr *streamSessionManager)
 			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
-		clearWriteDeadline := applyStreamablePOSTWriteDeadline(w, opts.POSTWriteTimeout)
-		defer clearWriteDeadline()
+		deadlineWriter := newLazyStreamablePOSTWriteDeadline(w, opts.POSTWriteTimeout)
+		defer deadlineWriter.clear()
+		w = deadlineWriter
 		principal, err := opts.Authenticator.Authenticate(r.Context(), r)
 		if err != nil {
 			logHTTPAuthFailure("streamable_http", r, err)
@@ -391,19 +392,45 @@ func streamableRPCHandler(opts StreamableHTTPOptions, mgr *streamSessionManager)
 	})
 }
 
-func applyStreamablePOSTWriteDeadline(w http.ResponseWriter, timeout time.Duration) func() {
+type lazyStreamablePOSTWriteDeadline struct {
+	http.ResponseWriter
+	timeout time.Duration
+	applied bool
+}
+
+func newLazyStreamablePOSTWriteDeadline(w http.ResponseWriter, timeout time.Duration) *lazyStreamablePOSTWriteDeadline {
 	if timeout == 0 {
 		timeout = defaultStreamablePOSTWriteTimeout
 	}
-	if timeout < 0 {
-		return func() {}
+	return &lazyStreamablePOSTWriteDeadline{ResponseWriter: w, timeout: timeout}
+}
+
+func (w *lazyStreamablePOSTWriteDeadline) WriteHeader(statusCode int) {
+	w.apply()
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *lazyStreamablePOSTWriteDeadline) Write(p []byte) (int, error) {
+	w.apply()
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *lazyStreamablePOSTWriteDeadline) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *lazyStreamablePOSTWriteDeadline) apply() {
+	if w.applied || w.timeout < 0 {
+		return
 	}
-	rc := http.NewResponseController(w)
-	if err := rc.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
-		return func() {}
+	if err := http.NewResponseController(w.ResponseWriter).SetWriteDeadline(time.Now().Add(w.timeout)); err == nil {
+		w.applied = true
 	}
-	return func() {
-		_ = rc.SetWriteDeadline(time.Time{})
+}
+
+func (w *lazyStreamablePOSTWriteDeadline) clear() {
+	if w.applied {
+		_ = http.NewResponseController(w.ResponseWriter).SetWriteDeadline(time.Time{})
 	}
 }
 

--- a/internal/mcp/transport_streamable_http_test.go
+++ b/internal/mcp/transport_streamable_http_test.go
@@ -207,12 +207,42 @@ func newTestStreamableStack(t *testing.T) (*streamSessionManager, StreamableHTTP
 
 type writeDeadlineRecorder struct {
 	*httptest.ResponseRecorder
+	mu        sync.Mutex
 	deadlines []time.Time
 }
 
 func (r *writeDeadlineRecorder) SetWriteDeadline(t time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.deadlines = append(r.deadlines, t)
 	return nil
+}
+
+func (r *writeDeadlineRecorder) deadlineCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deadlines)
+}
+
+func (r *writeDeadlineRecorder) deadlineAt(i int) time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.deadlines[i]
+}
+
+type blockingAuthenticator struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (a blockingAuthenticator) Authenticate(ctx context.Context, _ *http.Request) (authn.Principal, error) {
+	close(a.entered)
+	select {
+	case <-a.release:
+		return authn.Principal{Subject: "blocked-user", TenantID: "tenant-a"}, nil
+	case <-ctx.Done():
+		return authn.Principal{}, ctx.Err()
+	}
 }
 
 func TestStreamableRPCHandlerAppliesPOSTWriteDeadline(t *testing.T) {
@@ -225,17 +255,52 @@ func TestStreamableRPCHandlerAppliesPOSTWriteDeadline(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+testBearerToken)
 	handler.ServeHTTP(rec, req)
 
-	if len(rec.deadlines) != 2 {
-		t.Fatalf("deadline calls=%d, want set+clear", len(rec.deadlines))
+	if rec.deadlineCount() != 2 {
+		t.Fatalf("deadline calls=%d, want set+clear", rec.deadlineCount())
 	}
-	if rec.deadlines[0].IsZero() {
+	if rec.deadlineAt(0).IsZero() {
 		t.Fatal("first deadline should set a non-zero write deadline")
 	}
-	if got := time.Until(rec.deadlines[0]); got < time.Second || got > 2*time.Second {
+	if got := time.Until(rec.deadlineAt(0)); got < time.Second || got > 2*time.Second {
 		t.Fatalf("deadline delta=%s, want around 1.25s", got)
 	}
-	if !rec.deadlines[1].IsZero() {
-		t.Fatalf("second deadline should clear the deadline, got %s", rec.deadlines[1])
+	if !rec.deadlineAt(1).IsZero() {
+		t.Fatalf("second deadline should clear the deadline, got %s", rec.deadlineAt(1))
+	}
+}
+
+func TestStreamableRPCHandlerPOSTWriteDeadlineStartsAtFirstWrite(t *testing.T) {
+	mgr, opts := newTestStreamableStack(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	opts.Authenticator = blockingAuthenticator{entered: entered, release: release}
+	opts.POSTWriteTimeout = 1250 * time.Millisecond
+	handler := streamableRPCHandler(opts, mgr)
+
+	rec := &writeDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{`))
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.ServeHTTP(rec, req)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("authenticator was not called")
+	}
+	if got := rec.deadlineCount(); got != 0 {
+		t.Fatalf("deadline should not be set before authentication returns, got %d calls", got)
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not finish")
+	}
+	if rec.deadlineCount() != 2 {
+		t.Fatalf("deadline calls=%d, want set+clear", rec.deadlineCount())
 	}
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -100,6 +100,8 @@ func ResolveUserID(ctx context.Context, client *clockify.Client, workspaceID, re
 		query["name"] = ref
 		query["strict-name-search"] = "true"
 	}
+	matches := 0
+	matchedID := ""
 	for page := 1; ; page++ {
 		query["page"] = strconv.Itoa(page)
 		var users []map[string]any
@@ -107,29 +109,31 @@ func ResolveUserID(ctx context.Context, client *clockify.Client, workspaceID, re
 			return "", err
 		}
 
-		var matches []map[string]any
 		for _, user := range users {
 			name, _ := user["name"].(string)
 			email, _ := user["email"].(string)
+			matched := false
 			if isEmail {
 				if strings.EqualFold(email, ref) {
-					matches = append(matches, user)
+					matched = true
 				}
 			} else {
 				if strings.EqualFold(name, ref) || strings.EqualFold(email, ref) {
-					matches = append(matches, user)
+					matched = true
 				}
 			}
-		}
-		if len(matches) > 1 {
-			return "", fmt.Errorf("multiple users match '%s' (%d found). Use the full user ID instead", ref, len(matches))
-		}
-		if len(matches) == 1 {
-			id, _ := matches[0]["id"].(string)
+			if !matched {
+				continue
+			}
+			matches++
+			if matches > 1 {
+				return "", fmt.Errorf("multiple users match '%s' (%d found). Use the full user ID instead", ref, matches)
+			}
+			id, _ := user["id"].(string)
 			if id == "" {
 				return "", fmt.Errorf("user response missing id")
 			}
-			return id, nil
+			matchedID = id
 		}
 		if len(users) == 0 || len(users) < pageSize {
 			break
@@ -137,6 +141,9 @@ func ResolveUserID(ctx context.Context, client *clockify.Client, workspaceID, re
 		if page >= 1000 {
 			return "", fmt.Errorf("pagination safety stop reached: path=%s page-size=%d", path, pageSize)
 		}
+	}
+	if matchedID != "" {
+		return matchedID, nil
 	}
 	return "", fmt.Errorf("user '%s' not found. Use clockify_list_users to see available users", ref)
 }

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -183,7 +183,7 @@ func TestResolveUserIDPaginatesFilteredLookup(t *testing.T) {
 	}
 }
 
-func TestResolveUserIDStopsAfterFirstExactMatchPage(t *testing.T) {
+func TestResolveUserIDScansAfterFirstExactMatchForAmbiguity(t *testing.T) {
 	pageOne := make([]map[string]any, 200)
 	pageOne[0] = map[string]any{"id": "ccc333ddd444eee555fff666", "name": "Dana Scully", "email": "dana@example.com"}
 	for i := 1; i < len(pageOne); i++ {
@@ -208,15 +208,15 @@ func TestResolveUserIDStopsAfterFirstExactMatchPage(t *testing.T) {
 	})
 	defer cleanup()
 
-	id, err := ResolveUserID(context.Background(), client, "ws123", "Dana Scully")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := ResolveUserID(context.Background(), client, "ws123", "Dana Scully")
+	if err == nil {
+		t.Fatal("expected ambiguous user error")
 	}
-	if id != "ccc333ddd444eee555fff666" {
-		t.Fatalf("expected first-page user ID, got %s", id)
+	if !strings.Contains(err.Error(), "multiple users match") {
+		t.Fatalf("expected multiple-match error, got %v", err)
 	}
-	if strings.Join(pagesSeen, ",") != "1" {
-		t.Fatalf("expected resolver to stop after exact match on page 1, saw pages %v", pagesSeen)
+	if strings.Join(pagesSeen, ",") != "1,2" {
+		t.Fatalf("expected resolver to scan page 2 after first exact match, saw pages %v", pagesSeen)
 	}
 }
 


### PR DESCRIPTION
## Summary
- continue paginated user resolution after the first exact match so later duplicate matches still fail closed
- make streamable HTTP POST write deadlines lazy so long-running valid requests are not capped before response writing starts
- reconcile launch-state wording after PR #63 without implying new live Clockify evidence

## Verification
- go test ./internal/resolve -run 'TestResolveUserID'\n- go test ./internal/mcp -run 'TestStreamableRPCHandlerPOSTWriteDeadline|TestStreamableRPCHandlerAppliesPOSTWriteDeadline'\n- go test ./internal/mcp ./internal/resolve\n- make doc-parity\n- git diff --check\n- make check\n- GOTOOLCHAIN=local go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run\n\nNo live Clockify calls were run.