### PR TITLE
docs(launch): clarify mutation cron workflow fix has landed

### DIFF
--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -156,14 +156,17 @@ code/CI hardening backlog is tracked in
    `make launch-external-status` directly checks
    `CLOCKIFY_LIVE_AUDIT_REQUIRED=true` and prints maintainer action
    hints for each open gate while staying read-only.
-4. **Mutation cron evidence.** The local workflow timeout was raised
-   for the slow `internal/tools` leg, but `make launch-external-status`
-   recheck on 2026-05-09 shows latest scheduled mutation run
+4. **Mutation cron evidence.** The `internal/tools` matrix-leg
+   timeout increase landed on `main` in `2e7b6bd` ("May 9 hardening")
+   ahead of `308c815` and the later docs-only commits, so the
+   workflow fix is on the default branch. `make launch-external-status`
+   recheck on 2026-05-09 still shows latest scheduled mutation run
    25592823559 is `completed/cancelled` on pushed commit
-   `4fe957547f9e6aea749a85f87823d17a0ccc2928`. `gh run view` shows the
+   `4fe957547f9e6aea749a85f87823d17a0ccc2928` because that scheduled
+   cron fired before `2e7b6bd` landed; `gh run view` confirms only the
    `internal/tools` matrix leg was cancelled while the other mutation
-   legs succeeded. Wait for scheduled-run evidence on the final
-   candidate SHA after the workflow change lands.
+   legs succeeded. Wait for the next scheduled-run evidence on the
+   final candidate SHA now that the workflow fix is on `main`.
 5. **Paid-hosted external review and legal/commercial gates.** A paid
    hosted launch still needs the final plan's non-code evidence: the
    `Paid-hosted external security review`,

--- a/docs/launch-candidate-checklist.md
+++ b/docs/launch-candidate-checklist.md
@@ -464,8 +464,12 @@ checked.
       `completed/cancelled` on pushed commit
       4fe957547f9e6aea749a85f87823d17a0ccc2928. `gh run view` shows
       the `internal/tools` matrix leg was cancelled while the other
-      mutation legs succeeded. The local timeout increase still needs
-      pushed scheduled-run evidence on the final candidate SHA._
+      mutation legs succeeded. The `internal/tools` matrix-leg timeout
+      increase landed on `main` in `2e7b6bd` ("May 9 hardening")
+      ahead of `308c815` and the later docs-only commits, so the
+      workflow fix is on the default branch; the next scheduled
+      `mutation.yml` cron after that landing still needs to record a
+      green run on the final candidate SHA before this box can close._
 - [x] `make verify-bench` and `make bench-baseline-check` green;
       no regression > the documented threshold versus the
       baseline.

--- a/docs/launch-readiness-review-may-8.md
+++ b/docs/launch-readiness-review-may-8.md
@@ -821,20 +821,21 @@ prints a specific maintainer action beside each open gate.
   `docs/document-f3897b2-bypass` (`ahead=1`) and `fwbranch`
   (`ahead=20`) still contain commits ahead of `origin/main`; the other
   five are stale local pointers with `ahead=0`. The mutation cron
-  timeout has a local workflow fix in
-  this pass, but still needs the next scheduled run as evidence.
+  `internal/tools` matrix-leg timeout increase landed on `main` in
+  `2e7b6bd` ("May 9 hardening") ahead of `308c815` and the later
+  docs-only commits, so the workflow fix is on the default branch.
   Rechecked on 2026-05-09 via `make launch-external-status`: latest
-  `mutation.yml` scheduled run 25592823559 is now
+  `mutation.yml` scheduled run 25592823559 is still
   `completed/cancelled` on pushed commit
-  `4fe957547f9e6aea749a85f87823d17a0ccc2928`. `gh run view` shows the
+  `4fe957547f9e6aea749a85f87823d17a0ccc2928` because that scheduled
+  cron fired before `2e7b6bd` landed. `gh run view` confirms only the
   `internal/tools` matrix leg was cancelled while the other mutation
   legs succeeded. `make launch-external-status` now also prints that
-  non-green mutation matrix job and tells maintainers to land the
-  local timeout fix before waiting for the next scheduled success, so
-  handoffs do not need a separate `gh run view` inspection. These are
-  the open external pieces of
-  `G-02`, `G-03`, and `G-04`; the local timeout increase still needs
-  to land and prove a scheduled run on the final candidate SHA.
+  non-green mutation matrix job so handoffs do not need a separate
+  `gh run view` inspection. These are the open external pieces of
+  `G-02`, `G-03`, and `G-04`; the next scheduled `mutation.yml` cron
+  on the final candidate SHA still needs to record a green run with
+  the workflow fix in place before this gate can close.
 - **Public-repo stale PR hygiene.** The final integrated launch plan
   requires no open PRs older than 14 days unless they carry a `wip` or
   `blocked` label. `make launch-external-status` now checks the first


### PR DESCRIPTION
## Lane

Lane 1 — mutation cron evidence gate (`opus/mutation-cron-evidence-20260509`).

## Summary

The `internal/tools` matrix-leg timeout increase that the Group 7 mutation gate has been waiting on is no longer a local workflow fix — it landed on `main` in `2e7b6bd` ("May 9 hardening") ahead of `308c815` and the later docs-only commits. The launch checklist, agent handoff, and May 8 review ledger all still described it as local and "still needs to land". This PR rewrites those three tracking sentences to reflect what is actually true on the default branch, while leaving every checklist box exactly as it was: the gate is still red, the next scheduled cron on the final candidate SHA still has to record a green run with the workflow fix in place before Group 7's mutation box can close.

This PR is docs-only. No checklist box is ticked. Group 1 evidence on `feef83c641ced93d2ab6ba07ef766d61c82cc703` is unchanged. Groups 6 and 7 stay open per the operator brief.

## Evidence

`gh run list --repo apet97/go-clockify --workflow mutation.yml --event schedule --limit 10`:

- 2026-05-09 05:24:10Z — workflow_run_id: 25592823559 — `completed`/`cancelled` on `4fe957547f9e6aea749a85f87823d17a0ccc2928` — https://github.com/apet97/go-clockify/actions/runs/25592823559
- 2026-05-08 04:54:49Z — workflow_run_id: 25537573499 — `completed`/`cancelled` on `4fe957547f9e6aea749a85f87823d17a0ccc2928` — https://github.com/apet97/go-clockify/actions/runs/25537573499
- 2026-05-07 05:34:37Z — workflow_run_id: 25477911218 — `completed`/`cancelled` on `805d63ee999646ec633b799fd0fa6141bee863d6` — https://github.com/apet97/go-clockify/actions/runs/25477911218
- 2026-05-06 05:31:44Z — workflow_run_id: 25418275911 — `completed`/`success` on `805d63ee999646ec633b799fd0fa6141bee863d6` — https://github.com/apet97/go-clockify/actions/runs/25418275911

`gh run view 25592823559` confirms the May 9 cron fired on the pre-fix SHA: only `Mutation (internal/tools)` is `completed`/`cancelled`; `internal/truncate`, `internal/enforcement`, `internal/jsonschema`, `internal/mcp`, and `internal/ratelimit` are all `completed`/`success`.

`git log --oneline -- .github/workflows/mutation.yml` shows `2e7b6bd "May 9 hardening"` is the most recent change to `mutation.yml`. `git show 2e7b6bd -- .github/workflows/mutation.yml` shows the matrix-leg timeout going from `45` to `90` minutes. `git log a07443b..2e7b6bd` is empty and `git log 2e7b6bd..a07443b --oneline` lists `308c815`, `421442c`, `51dcc3f`, `feef83c`, `a07443b` — i.e. the workflow fix is on `main` ahead of every later commit.

`bash scripts/check-launch-external-status.sh` still reports `[open] mutation.yml: latest scheduled run is not green on a07443bb260974f263ae8f39349544b72d351aab; latest=25592823559/completed/cancelled/4fe957547f9e6aea749a85f87823d17a0ccc2928/2026-05-09T05:24:10Z` with the `Mutation (internal/tools) (completed/cancelled)` job line. No box ticks here either.

## Verification

- `make doc-parity` — `doc-parity: OK`, `launch-review-ledger: OK`, `launch-checklist-parity: OK`, `launch-evidence-gate: OK`.
- `make launch-checklist-parity` — `launch-checklist-parity: OK`, `launch-evidence-gate: OK`.
- `bash scripts/test-check-launch-external-status.sh` — 20 run, 0 failed.
- `git diff --check` — clean (no whitespace issues).

## Files touched

- `docs/launch-candidate-checklist.md` — Group 7 mutation tracking note rewritten.
- `docs/agent-handoff.md` — "Mutation cron evidence" open-gate bullet rewritten.
- `docs/launch-readiness-review-may-8.md` — "D7 / D9 branch protection, mutation cron, and stale local branches" tracking sentences rewritten.

## Out of scope

- No edits to `scripts/check-launch-external-status.sh` or its test: the helper's existing action message ("land the remediation tree containing the mutation timeout fix if it is not on the default branch, then wait for a scheduled mutation.yml success on the final candidate SHA and link the run URL.") is conditional and still correct; the assertion on this string in `scripts/test-check-launch-external-status.sh` is unchanged.
- No mutation.yml workflow edits: the timeout fix is already on `main`.
- No Group 1 / Group 6 / Group 7 box ticks. The gate remains red.

## Handoff notes for next agent

The gate closes when:

1. A scheduled `mutation.yml` cron fires on a candidate SHA that already includes `2e7b6bd` (i.e., any future `main` SHA), and
2. That run is `completed`/`success` (all six matrix legs green within the new 90-minute timeout) on the final candidate SHA.

At that point: tick the appropriate Group 7 box with the run URL + workflow_run_id and update the handoff/checklist tracking text from "still needs to record a green run" to "closed: workflow_run_id: NNNNN ...". Do not tick anything before then; do not declare launch-ready under any circumstances on the basis of this lane.