### PR TITLE
fix(release): rc.2 readiness — npm prerelease tag, deploy verify race, release-smoke trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,9 +107,32 @@ jobs:
           DIGEST: ${{ steps.image_digest.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign verify "$IMAGE@$DIGEST" \
-            --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/docker-image.yml@refs/tags/.*$' \
-            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+          # Deploy and Docker Image fire in parallel on the same tag
+          # push. The previous step's digest-lookup retry can succeed
+          # before Docker Image's `cosign sign` step pushes the
+          # signature — observed live in v1.2.1-rc.1 (Deploy run
+          # 25612037645): digest existed at 21:19:16Z, but `cosign
+          # sign` did not push the signature until 21:19:21Z, so
+          # `cosign verify` returned "no signatures found" 5 seconds
+          # before the signature became visible. Retry verify on the
+          # same 24x30s budget as the digest-lookup step (~12 minutes
+          # total) so a slow signature push does not red the workflow.
+          LAST_LOG="$(mktemp)"
+          for i in $(seq 1 24); do
+            if cosign verify "$IMAGE@$DIGEST" \
+              --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/docker-image.yml@refs/tags/.*$' \
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+              >"$LAST_LOG" 2>&1; then
+              cat "$LAST_LOG"
+              echo "Signature verified on attempt $i."
+              exit 0
+            fi
+            echo "Attempt $i: cosign verify pending (signature not yet visible). Sleeping 30s..."
+            sleep 30
+          done
+          echo "::error::cosign verify failed after 24 attempts (~12 minutes). Last attempt output:"
+          cat "$LAST_LOG"
+          exit 1
 
       - name: Download release binary for SLSA verification
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,3 +145,27 @@ jobs:
             --ref "${RELEASE_VERSION}" \
             -f tag="${RELEASE_VERSION}"
           echo "Dispatched. Monitor: gh run list --workflow=reproducibility.yml"
+      - name: Trigger release smoke verification
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # release-smoke.yml listens on `release: [published]` for
+          # the same GITHUB_TOKEN-suppression reason as reproducibility:
+          # the release is created by an action using GITHUB_TOKEN, so
+          # the published event never reaches release-smoke. Observed
+          # live for v1.2.1-rc.1 — Release ran, the GitHub Release
+          # object was created, but release-smoke never auto-fired.
+          # Dispatch it explicitly here using the workflow_dispatch
+          # trigger that release-smoke.yml already supports. The
+          # workflow file lives on `main`, so --ref must be `main`
+          # (workflow_dispatch can only target a ref where the
+          # workflow file exists); the `tag` input passes the rc
+          # tag through to the verifier steps.
+          echo "Dispatching release-smoke.yml for tag ${RELEASE_VERSION}"
+          gh workflow run release-smoke.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f tag="${RELEASE_VERSION}"
+          echo "Dispatched. Monitor: gh run list --workflow=release-smoke.yml"

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ script-tests:
 	bash scripts/test-check-live-tool-coverage.sh
 	bash scripts/test-collect-license-evidence.sh
 	bash scripts/test-prepare-rc-evidence.sh
+	bash scripts/test-publish-npm.sh
 	bash scripts/test-claude-campaign.sh
 
 claude-campaign-plan:

--- a/docs/runbooks/release-candidate-evidence.md
+++ b/docs/runbooks/release-candidate-evidence.md
@@ -223,3 +223,28 @@ fail-closed validator before treating workflow-backed boxes as closed.
 - `docs/release-policy.md`
 - `docs/verification.md`
 - `.github/workflows/release-smoke.yml`
+
+## Failed-evidence record — v1.2.1-rc.1 (2026-05-09)
+
+`v1.2.1-rc.1` was cut on `a5d5f75769dc834a268f6ab24949b139ac4cff85` and is **preserved as failed-evidence only** — it is **not** a releasable RC. Recorded here so future RC work (rc.2+) does not silently re-hit the same failures and so the rc.2 fix bundle has a referenceable baseline.
+
+| Workflow | Run ID | Result | Failure point |
+|---|---|---|---|
+| Docker Image | [25612037638](https://github.com/apet97/go-clockify/actions/runs/25612037638) | ✅ success | `Build, scan, sign` job; `cosign sign` pushed signature at 21:19:21Z (`tlog entry created with index: 1487221873`) |
+| Release (goreleaser) | [25612037642](https://github.com/apet97/go-clockify/actions/runs/25612037642) | ❌ failure | Step `Publish npm packages` exit 1 — `npm error You must specify a tag using --tag when publishing a prerelease version.` First package staged was `@apet97/clockify-mcp-go-darwin-arm64@1.2.1-rc.1`. |
+| Deploy | [25612037645](https://github.com/apet97/go-clockify/actions/runs/25612037645) | ❌ failure | Step `Verify image signature` exit 10 — `Error: no signatures found`. Verify ran at 21:19:16Z, signature not pushed until 21:19:21Z (5-second timing race against Docker Image's `cosign sign`). |
+| `release-smoke.yml` (release event) | _not fired_ | — | Did not auto-trigger. The Release workflow uses `GITHUB_TOKEN` to publish the GitHub Release object, and GitHub suppresses downstream workflow triggers from `GITHUB_TOKEN`-driven actions, so `release: [published]` never reached release-smoke. |
+
+Asset state on the rc.1 GitHub Release object remained intact:
+
+- 47 release assets uploaded between 21:19:47Z and 21:19:56Z (binaries, `.sigstore.json` cosign bundles, `.spdx.json` SBOMs, `SHA256SUMS.txt`).
+- GitHub Release object: `name=v1.2.1-rc.1`, `isPrerelease=true`, `isDraft=false`, `publishedAt=2026-05-09T21:19:56Z`.
+- No partial npm publish — `Publish npm packages` aborted on the first staged package, before any `npm publish` request reached the registry. Verifiable: `npm view @apet97/clockify-mcp-go-darwin-arm64@1.2.1-rc.1` returns 404; `@apet97/clockify-mcp-go` `dist-tags.latest` remains `1.2.0`.
+
+Why these are **not** transient and require an rc.2:
+
+1. **npm `--tag` script bug.** `scripts/publish-npm.sh` did not pass `--tag` for prereleases. Re-running the same Release workflow on the same `v1.2.1-rc.1` tag would hit the identical failure because the workflow runs against the tag's tree and the script bug is on that tree. **Fix-and-retag (rc.2) is required.**
+2. **Deploy timing race.** The image **is** correctly signed (Docker Image's `cosign sign` step succeeded with tlog index 1487221873). Deploy's `Verify image signature` simply ran 5 seconds early. Rerunning the failed Deploy run on rc.1 will pass — but rc.1's npm gate stays unproven regardless. The deploy.yml fix wraps `cosign verify` in the same 24×30s retry budget as the digest-lookup step so the race cannot recur on rc.2+.
+3. **release-smoke not firing.** Architectural — `GITHUB_TOKEN`-suppressed event chain. The release.yml fix adds an explicit `gh workflow run release-smoke.yml --ref main -f tag=$RELEASE_VERSION` step after the existing `Trigger reproducibility verification` step (mirrors the same pattern reproducibility.yml uses for the same reason).
+
+rc.2 cuts only after the fix PR for these three issues lands on `main`. This runbook is updated again with the rc.2 evidence pointers when rc.2's Release / Docker Image / Deploy / release-smoke / npm-publish all complete green and the Group 7 evidence is recordable.

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -23,6 +23,30 @@ fi
 RAW_VERSION="$1"
 VERSION="${RAW_VERSION#v}"  # strip leading v — npm semver must be bare
 
+# npm refuses to publish a prerelease without an explicit --tag (the
+# v1.2.1-rc.1 release workflow failed at exactly this step:
+# "npm error You must specify a tag using --tag when publishing a
+# prerelease version."). Stable releases must still publish without
+# --tag so npm defaults the dist-tag to "latest". Prereleases must
+# choose an explicit channel: rc / beta / alpha / next (catch-all).
+NPM_DIST_TAG=""
+if [[ "$VERSION" == *-* ]]; then
+  pre_first_id="$(echo "${VERSION#*-}" | sed 's/[.+].*$//' | tr '[:upper:]' '[:lower:]')"
+  case "$pre_first_id" in
+    rc)    NPM_DIST_TAG="rc" ;;
+    beta)  NPM_DIST_TAG="beta" ;;
+    alpha) NPM_DIST_TAG="alpha" ;;
+    *)     NPM_DIST_TAG="next" ;;
+  esac
+fi
+
+# All npm publish invocations use this argv shape so the dist-tag
+# decision is made once and applies uniformly to every package.
+NPM_PUBLISH_ARGS=(--access public)
+if [ -n "$NPM_DIST_TAG" ]; then
+  NPM_PUBLISH_ARGS+=(--tag "$NPM_DIST_TAG")
+fi
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEMPLATE="$REPO_ROOT/npm/package.json.tmpl"
 BASE_DIR="$REPO_ROOT/npm/clockify-mcp-go"
@@ -55,7 +79,7 @@ publish_platform() {
   local pkg_dir="$WORK_DIR/platform-$suffix"
   local pkg_name="@apet97/clockify-mcp-go-$suffix"
 
-  echo "[npm] staging $pkg_name@$VERSION from $src"
+  echo "[npm] staging $pkg_name@$VERSION from $src${NPM_DIST_TAG:+ (--tag $NPM_DIST_TAG)}"
   if [ ! -f "$REPO_ROOT/$src" ]; then
     echo "error: expected binary $REPO_ROOT/$src not found — did goreleaser run?" >&2
     exit 1
@@ -80,7 +104,7 @@ publish_platform() {
     -e "s|CPU_VALUE|$cpu|g" \
     "$TEMPLATE" > "$pkg_dir/package.json"
 
-  (cd "$pkg_dir" && npm publish --access public)
+  (cd "$pkg_dir" && npm publish "${NPM_PUBLISH_ARGS[@]}")
 }
 
 publish_base() {
@@ -91,8 +115,8 @@ publish_base() {
     xargs -0 sed -i.bak -e "s|VERSION|$VERSION|g"
   find "$pkg_dir" -type f -name '*.bak' -delete
   chmod +x "$pkg_dir/bin/clockify-mcp.js"
-  echo "[npm] publishing base package @apet97/clockify-mcp-go@$VERSION"
-  (cd "$pkg_dir" && npm publish --access public)
+  echo "[npm] publishing base package @apet97/clockify-mcp-go@$VERSION${NPM_DIST_TAG:+ (--tag $NPM_DIST_TAG)}"
+  (cd "$pkg_dir" && npm publish "${NPM_PUBLISH_ARGS[@]}")
 }
 
 for row in "${PLATFORMS[@]}"; do

--- a/scripts/test-publish-npm.sh
+++ b/scripts/test-publish-npm.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# test-publish-npm.sh — regression test for scripts/publish-npm.sh.
+#
+# Locks the prerelease-tag contract that broke v1.2.1-rc.1's Release
+# workflow at the "Publish npm packages" step: npm refuses to publish a
+# prerelease version without an explicit --tag. The fix branch makes
+# publish-npm.sh derive --tag from the semver prerelease identifier;
+# this test pins the contract so a future refactor cannot regress to
+# the v1.2.1-rc.1 failure mode.
+#
+# Cases:
+#   1. v1.2.1-rc.2     → all 6 publishes pass --tag rc
+#   2. v1.2.1          → no publish carries --tag (npm defaults to latest)
+#   3. v2.0.0-beta.1   → all 6 publishes pass --tag beta
+#   4. v2.0.0-alpha.1  → all 6 publishes pass --tag alpha
+#   5. v1.0.0-pre.5    → all 6 publishes pass --tag next (catch-all)
+#   6. V1.2.1-RC.3     → uppercase prerelease still routes to --tag rc
+#                        (case-insensitive identifier matching)
+#   7. v1.2.3-rc       → bare "rc" identifier (no .N) still routes to rc
+#
+# Each case sandboxes the script in a fresh tmp REPO_ROOT with a fake
+# npm command that records its argv. No real npm publish happens.
+#
+# This test is a sibling to scripts/test-check-release-assets.sh in
+# spirit (per-case tmp fixtures, exit-code + output assertions, pure
+# bash, no external services). It is wired into the Makefile under
+# the script-tests target.
+
+set -euo pipefail
+
+repo_root_real="$(cd "$(dirname "$0")/.." && pwd)"
+script_under_test="$repo_root_real/scripts/publish-npm.sh"
+template_real="$repo_root_real/npm/package.json.tmpl"
+base_dir_real="$repo_root_real/npm/clockify-mcp-go"
+
+if [ ! -x "$script_under_test" ]; then
+  echo "FAIL: $script_under_test not executable" >&2
+  exit 1
+fi
+if [ ! -f "$template_real" ]; then
+  echo "FAIL: $template_real not found (real template required as a copy source)" >&2
+  exit 1
+fi
+if [ ! -d "$base_dir_real" ]; then
+  echo "FAIL: $base_dir_real not found (real base package required as a copy source)" >&2
+  exit 1
+fi
+
+tmproot="$(mktemp -d)"
+trap 'rm -rf "$tmproot"' EXIT
+
+tests_run=0
+tests_failed=0
+
+# Per-case sandbox: copy the script to $sandbox/scripts/publish-npm.sh
+# so the script's REPO_ROOT (resolved via $(dirname "$0")/..) lands at
+# $sandbox. Provide a minimal npm/package.json.tmpl + base package +
+# empty platform binaries so the script runs without touching the
+# real repo. Inject a fake npm via PATH that just records argv.
+build_sandbox() {
+  local sandbox="$1"
+  mkdir -p "$sandbox/scripts" "$sandbox/npm/clockify-mcp-go/bin" "$sandbox/bin"
+
+  cp "$script_under_test" "$sandbox/scripts/publish-npm.sh"
+  chmod +x "$sandbox/scripts/publish-npm.sh"
+
+  cp "$template_real" "$sandbox/npm/package.json.tmpl"
+  cp -R "$base_dir_real/." "$sandbox/npm/clockify-mcp-go/"
+
+  for path in \
+    "dist/clockify-mcp_darwin_arm64_v8.0/clockify-mcp" \
+    "dist/clockify-mcp_darwin_amd64_v1/clockify-mcp" \
+    "dist/clockify-mcp_linux_amd64_v1/clockify-mcp" \
+    "dist/clockify-mcp_linux_arm64_v8.0/clockify-mcp" \
+    "dist/clockify-mcp_windows_amd64_v1/clockify-mcp.exe"
+  do
+    mkdir -p "$sandbox/$(dirname "$path")"
+    : > "$sandbox/$path"
+  done
+
+  cat > "$sandbox/bin/npm" <<'NPMEOF'
+#!/usr/bin/env bash
+# Mock npm — record argv on its own line and succeed.
+# The real test harness greps the log for ^publish vs ^deprecate.
+echo "$@" >> "${NPM_INVOCATIONS_LOG:?NPM_INVOCATIONS_LOG must be set}"
+exit 0
+NPMEOF
+  chmod +x "$sandbox/bin/npm"
+}
+
+run_case() {
+  local case_name="$1" version="$2" expected_tag="$3"
+  tests_run=$((tests_run+1))
+
+  local sandbox="$tmproot/case-$tests_run"
+  build_sandbox "$sandbox"
+
+  local invocations_log="$sandbox/npm-invocations.log"
+  : > "$invocations_log"
+
+  if ! NPM_INVOCATIONS_LOG="$invocations_log" \
+       PATH="$sandbox/bin:$PATH" \
+       bash "$sandbox/scripts/publish-npm.sh" "$version" \
+       >"$sandbox/script.out" 2>"$sandbox/script.err"; then
+    echo "FAIL [$case_name]: script exited non-zero (version=$version)"
+    sed 's/^/    /' "$sandbox/script.err" >&2 || true
+    tests_failed=$((tests_failed+1))
+    return
+  fi
+
+  local publish_count
+  publish_count=$(grep -c '^publish ' "$invocations_log" || true)
+  if [ "$publish_count" -ne 6 ]; then
+    echo "FAIL [$case_name]: expected exactly 6 'npm publish' invocations, got $publish_count"
+    echo "  invocations log:" >&2
+    sed 's/^/    /' "$invocations_log" >&2 || true
+    tests_failed=$((tests_failed+1))
+    return
+  fi
+
+  if [ "$expected_tag" = "-" ]; then
+    if grep -q '^publish .*--tag' "$invocations_log"; then
+      echo "FAIL [$case_name]: stable version $version should NOT pass --tag, but did"
+      sed 's/^/    /' "$invocations_log" >&2 || true
+      tests_failed=$((tests_failed+1))
+      return
+    fi
+    local access_count
+    access_count=$(grep -c '^publish --access public$' "$invocations_log" || true)
+    if [ "$access_count" -ne 6 ]; then
+      echo "FAIL [$case_name]: expected 6 'publish --access public' (no extras), got $access_count"
+      sed 's/^/    /' "$invocations_log" >&2 || true
+      tests_failed=$((tests_failed+1))
+      return
+    fi
+  else
+    local tagged_count
+    tagged_count=$(grep -cE "^publish --access public --tag ${expected_tag}\$" "$invocations_log" || true)
+    if [ "$tagged_count" -ne 6 ]; then
+      echo "FAIL [$case_name]: expected 6 'publish --access public --tag $expected_tag', got $tagged_count"
+      sed 's/^/    /' "$invocations_log" >&2 || true
+      tests_failed=$((tests_failed+1))
+      return
+    fi
+  fi
+
+  echo "[pass] $case_name (version=$version → tag=${expected_tag/-/<none>})"
+}
+
+run_case "rc.2 prerelease"       "v1.2.1-rc.2"     "rc"
+run_case "stable release"        "v1.2.1"          "-"
+run_case "beta prerelease"       "v2.0.0-beta.1"   "beta"
+run_case "alpha prerelease"      "v2.0.0-alpha.1"  "alpha"
+run_case "unknown prerelease"    "v1.0.0-pre.5"    "next"
+run_case "uppercase rc"          "V1.2.1-RC.3"     "rc"
+run_case "bare rc identifier"    "v1.2.3-rc"       "rc"
+
+echo
+echo "publish-npm tests: $tests_run run, $tests_failed failed"
+[ "$tests_failed" -eq 0 ]


### PR DESCRIPTION
> 🚧 **Draft. Do not merge until operator review.** This PR prepares the codebase for cutting `v1.2.1-rc.2` after operator decision on 2026-05-09 (Option A from the rc.1 failure report). It does NOT retag rc.1, cut rc.2, dispatch any workflows for rc.1, change branch protection, close issue #78, or claim launch-ready.

## Summary

Fix the three real failures observed against `v1.2.1-rc.1` so the next rc cut can produce green Group 7 evidence end-to-end. rc.1 remains as failed-evidence-only and is documented in the runbook.

## Failures being fixed (and the rc.1 evidence)

| # | Failure | Run | Root cause | Fix in this PR |
|---|---|---|---|---|
| 1 | `Release` / `Publish npm packages` | [25612037642](https://github.com/apet97/go-clockify/actions/runs/25612037642) | `scripts/publish-npm.sh` did not pass `--tag` for prereleases. `npm error You must specify a tag using --tag when publishing a prerelease version.` First package staged was `@apet97/clockify-mcp-go-darwin-arm64@1.2.1-rc.1`; npm aborted before any publish reached the registry — **no partial publish occurred** (`@apet97/clockify-mcp-go` `dist-tags.latest` is still `1.2.0`). | Derive npm dist-tag from the semver prerelease identifier (`rc.* → rc`, `beta.* → beta`, `alpha.* → alpha`, else `next`). Stable releases continue to publish without `--tag` so npm defaults to `latest`. |
| 2 | `Deploy` / `Verify image signature` | [25612037645](https://github.com/apet97/go-clockify/actions/runs/25612037645) | Timing race. Verify ran at 21:19:16Z; Docker Image's `cosign sign` step did not push the signature until 21:19:21Z (`tlog entry created with index: 1487221873`). Image **is** signed correctly. | Wrap `cosign verify` in a 24×30s bounded retry, matching the budget already used by the previous step's digest-lookup retry. Same pattern used by reproducibility-trigger logic for the same class of issue. |
| 3 | `release-smoke.yml` did not auto-fire | _no run_ | Architectural. The Release workflow uses `GITHUB_TOKEN` to publish the GitHub Release object; GitHub suppresses downstream workflow events from `GITHUB_TOKEN`-driven actions, so `release: [published]` never reaches release-smoke. | Add a `Trigger release smoke verification` step after the existing `Trigger reproducibility verification` step in release.yml; explicit `gh workflow run release-smoke.yml --ref main -f tag="$RELEASE_VERSION"`. Mirrors the existing workaround for reproducibility.yml. |

## Files changed

| File | Change |
|---|---|
| `scripts/publish-npm.sh` | Detect prerelease, derive dist-tag, build a single `NPM_PUBLISH_ARGS` array, pass to all platform publishes + base publish. |
| `scripts/test-publish-npm.sh` (new, +161 lines) | Regression test pinning the dist-tag contract through 7 cases (rc, stable, beta, alpha, catch-all `next`, uppercase, bare `rc`). Sandbox per case with a fake `npm` on PATH; asserts exit code, total publish count, per-publish argv shape. No network, no real npm publish. |
| `.github/workflows/deploy.yml` | `Verify image signature` step wraps `cosign verify` in a 24×30s retry loop. Identity regex and OIDC issuer unchanged. |
| `.github/workflows/release.yml` | Add `Trigger release smoke verification` step at the end of the GoReleaser job, after the existing reproducibility trigger. |
| `Makefile` | Add `bash scripts/test-publish-npm.sh` to the `script-tests` target. |
| `docs/runbooks/release-candidate-evidence.md` | New `Failed-evidence record — v1.2.1-rc.1 (2026-05-09)` section: workflow run IDs, exact failure points, asset state, and explicit reasoning for why rc.2 is required vs reusing rc.1. |

## Verification

- [x] `bash scripts/test-publish-npm.sh` — **7/7 pass**
- [x] `make script-tests` — all suites green (publish-npm + claude-campaign + the existing 17 others)
- [x] `make doc-parity` — `doc-parity` / `launch-review-ledger` / `launch-checklist-parity` / `launch-evidence-gate` all OK
- [x] `make launch-checklist-parity` — OK
- [x] `git diff --check` — clean
- [ ] Reviewer spot-check: confirm `--tag rc` derivation matches the operator-specified mapping (rc/beta/alpha/next).
- [ ] Reviewer spot-check: confirm Deploy retry budget (24×30s = ~12 min) is adequate.
- [ ] Reviewer spot-check: confirm release-smoke trigger uses `--ref main` (workflow file lives there) with `tag` input set to the rc tag (workflow file's input is named `tag`).

## What this PR does NOT do (per operator standing instructions)

- ❌ Retag `v1.2.1-rc.1`.
- ❌ Cut `v1.2.1-rc.2`.
- ❌ Manually dispatch `release-smoke.yml` for rc.1.
- ❌ Rerun the failed Deploy run for rc.1.
- ❌ Change branch protection on `main`.
- ❌ Close issue #78 (the 19-context branch-protection follow-up stays open through RC evidence work).
- ❌ Claim launch-ready.

## Sequence after merge

1. Operator reviews and merges this PR.
2. CI on main goes green.
3. Operator cuts `v1.2.1-rc.2` on the new main HEAD (operator action — coordinator does not cut tags).
4. Lanes 2 (Group 6 security) and 3 (Group 7 release evidence) re-run against rc.2 to produce closed-gate evidence.
5. Issue #78 stays open until the 19-context restoration is its own follow-up.

## Related

- Closes (no issues — this is a fix bundle, not gate closure)
- Failed-evidence record: see `docs/runbooks/release-candidate-evidence.md` § "Failed-evidence record — v1.2.1-rc.1"
- Tracking: issue #78 (19-context branch-protection restoration; unaffected by this PR)
