### PR TITLE
docs(launch): record v1.2.1-rc.2 Group 7 evidence

### DIFF
--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -141,9 +141,46 @@ code/CI hardening backlog is tracked in
    evidence. The Semgrep workflow artifact still needs its first
    pushed-run evidence and does not replace the candidate-tag scan.
    File findings or explicit "no findings" evidence in `SECURITY.md`.
-2. **Release/sigstore/SLSA evidence.** The candidate tag still
-   needs `release-smoke.yml`, sigstore/SLSA/SBOM verification, and
-   archived `doctor --strict` outputs for the reference deployment.
+2. **Release/sigstore/SLSA evidence.** Partially closed on
+   2026-05-10 against rc.2 candidate SHA
+   `d83f9f86d3b95594abef2ee035554510faa799c1` (peeled from annotated
+   tag SHA `681079e571bed0efbfd448129a3d9fa1de58cd15`):
+   `release-smoke.yml` run 25613270137 is green
+   (https://github.com/apet97/go-clockify/actions/runs/25613270137);
+   it auto-fired on rc.2 via the new explicit `workflow_dispatch`
+   trigger added to `release.yml` in PR #80, verified `cosign
+   verify-blob` for `clockify-mcp-linux-x64` +
+   `clockify-mcp-postgres-linux-x64` (both `Verified OK`), `gh
+   attestation verify` for the same two binaries (SLSA — rc.2
+   attestations report
+   `sourceRepositoryVisibilityAtSigning="public"`), `cosign verify
+   ghcr.io/apet97/go-clockify@sha256:4171a582016b55ae5365d626b697831c7146c7c3bed9cef134be91ef8083a3b5`,
+   and uploaded the `release-smoke-doctor-output` artifact
+   (https://api.github.com/repos/apet97/go-clockify/actions/artifacts/6899048388/zip)
+   with `release-doctor-strict-ok.txt`,
+   `release-doctor-strict-fail.txt`, and
+   `release-doctor-postgres-ok.txt`. Local manual `cosign
+   verify-blob` against the FIPS variant
+   (`clockify-mcp-fips-linux-x64.sigstore.json`) returns `Verified
+   OK`. The release artefact and reference-deployment doctor boxes
+   are now closed in `docs/launch-candidate-checklist.md` Group 7;
+   the `release-candidate-evidence.md` runbook records the rc.2
+   evidence pointers alongside the rc.1 failed-evidence record.
+   Two rc.2-specific NEW findings remain open and are owned by
+   other lanes: (a) `reproducibility.yml` run 25613269789 failed
+   with sha256 mismatches on `clockify-mcp-fips-linux-x64`,
+   `clockify-mcp-darwin-arm64`, `clockify-mcp-fips-darwin-arm64`,
+   and `clockify-mcp-fips-darwin-x64` (cosign and SLSA still
+   verify; reproducibility means bit-identical rebuild diverges,
+   not provenance); (b) Deploy run 25613215498 failed because the
+   `Verify Release Assets / Download release binary for SLSA
+   verification` step's `gh release download` ran 9 seconds before
+   the GitHub Release object finished publishing (download
+   22:20:29Z, publishedAt 22:20:38Z) — PR #80's cosign-verify
+   retry budget did not extend to the release-asset download
+   step. Neither failure invalidates the rc.2 release artefacts;
+   both are CI-pipeline races/regressions that the next lane on
+   those workflows owns.
 3. **Externally visible repo-state cleanup.** Rechecked on 2026-05-09
    after `a07443b` landed: CodeQL run 25609129989, Dependency Review
    run 25609129978, and Semgrep run 25609129983 are green on the

--- a/docs/launch-candidate-checklist.md
+++ b/docs/launch-candidate-checklist.md
@@ -470,6 +470,19 @@ checked.
       workflow fix is on the default branch; the next scheduled
       `mutation.yml` cron after that landing still needs to record a
       green run on the final candidate SHA before this box can close._
+      _Tracking 2026-05-10 on rc.2 candidate SHA
+      `d83f9f86d3b95594abef2ee035554510faa799c1`: scheduled
+      `live-contract.yml` greens still pre-date rc.2 (workflow_run_id:
+      25608259477 / 25607242862 on `feef83c6`); `release-smoke.yml`
+      run 25613270137 is green on rc.2 via the new explicit
+      `workflow_dispatch` trigger added in PR #80; `reproducibility.yml`
+      run 25613269789 FAILED on rc.2 with sha256 mismatches across the
+      FIPS (linux-x64) and darwin (arm64, x64) binaries — local
+      rebuild bytes diverge from the published assets, indicating a
+      goreleaser/Go-toolchain non-determinism that has not been
+      triaged. This box stays open until reproducibility.yml is green
+      on the candidate SHA in addition to the previously tracked
+      mutation.yml gap. https://github.com/apet97/go-clockify/actions/runs/25613269789_
 - [x] `make verify-bench` and `make bench-baseline-check` green;
       no regression > the documented threshold versus the
       baseline.
@@ -478,14 +491,44 @@ checked.
       25255062599, validated locally with `make bench-baseline-check`,
       then passed linux/amd64 comparison in
       https://github.com/apet97/go-clockify/actions/runs/25255216987._
-- [ ] Release artefacts: signed binaries (cosign, plus SLSA when
+- [x] Release artefacts: signed binaries (cosign, plus SLSA when
       GitHub artifact attestations are available), SBOMs,
       Docker images, FIPS variant. Verified by `release-smoke.yml`
       on the candidate tag for its sampled default/Postgres
       linux-x64 artifacts, plus manual `docs/verification.md`
       evidence for any required variant not sampled by
       `release-smoke.yml`.
-- [ ] `clockify-mcp doctor --strict` and
+      _Closed 2026-05-10 on rc.2 candidate SHA
+      `d83f9f86d3b95594abef2ee035554510faa799c1`: workflow_run_id:
+      25613270137,
+      https://github.com/apet97/go-clockify/actions/runs/25613270137,
+      release-smoke.yml workflow_dispatch on rc.2 verified `cosign
+      verify-blob` for `clockify-mcp-linux-x64` and
+      `clockify-mcp-postgres-linux-x64` (both `Verified OK`),
+      `gh attestation verify` for the same two binaries (SLSA
+      provenance succeeded — sourceRepositoryVisibilityAtSigning was
+      `public` on the rc.2 attestations), and `cosign verify
+      ghcr.io/apet97/go-clockify@sha256:4171a582016b55ae5365d626b697831c7146c7c3bed9cef134be91ef8083a3b5`
+      for the multi-arch container image (`OK: cosign verify
+      ghcr.io/apet97/go-clockify@sha256:4171…3b5`). Manual FIPS
+      variant evidence was captured locally per
+      `docs/verification.md` step 2 against the published rc.2
+      `clockify-mcp-fips-linux-x64.sigstore.json` bundle (`Verified
+      OK`). The 46-asset structural contract from
+      `scripts/check-release-assets.sh` returned `OK: all 46 expected
+      release assets present` against the rc.2 GitHub Release object.
+      The Release object also carries one supplementary
+      package-level SBOM whose name embeds the image digest
+      (`sha256:4171…3b5`); 47 total assets, but the count is not a
+      regression because the structural check excludes that name from
+      the contract surface.
+      Local SLSA verify of `clockify-mcp-linux-x64` recorded all 15
+      binary subjects in the SLSA provenance statement, with
+      `builder.id =
+      https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/v1.2.1-rc.2`
+      and `runDetails.metadata.invocationId =
+      https://github.com/apet97/go-clockify/actions/runs/25613215490/attempts/1`._
+- [x] `clockify-mcp doctor --strict` and
       `clockify-mcp-postgres doctor --strict --check-backends`
       both exit 0 against the candidate's reference deployment.
       For `release-smoke.yml`, archive or link the
@@ -493,6 +536,31 @@ checked.
       `release-doctor-strict-ok.txt`,
       `release-doctor-strict-fail.txt`, and
       `release-doctor-postgres-ok.txt`.
+      _Closed 2026-05-10 on rc.2 candidate SHA
+      `d83f9f86d3b95594abef2ee035554510faa799c1`: workflow_run_id:
+      25613270137,
+      https://github.com/apet97/go-clockify/actions/runs/25613270137,
+      uploaded the `release-smoke-doctor-output` artifact
+      (https://api.github.com/repos/apet97/go-clockify/actions/artifacts/6899048388/zip)
+      containing all three required files. `release-doctor-strict-ok.txt`
+      shows `Strict posture: OK no fatal findings; 1 warning(s)` for
+      the default `clockify-mcp-linux-x64` binary under
+      `MCP_PROFILE=prod-postgres`. `release-doctor-postgres-ok.txt`
+      shows the same `Strict posture: OK` for the
+      `clockify-mcp-postgres-linux-x64` binary with the workflow's
+      Postgres service container (`--check-backends` succeeded).
+      `release-doctor-strict-fail.txt` shows the negative case
+      `Strict posture: ERROR 1 error finding(s)` with
+      `CLOCKIFY_POLICY` rejected when broader than `time_tracking_safe`,
+      proving the strict gate is wired in the published binary. Local
+      doctor strict on the candidate-tag tree (built from HEAD
+      `d83f9f8…`) reproduces both behaviours: `MCP_PROFILE=prod-postgres
+      … doctor --strict` exits 0 and `CLOCKIFY_POLICY=standard …
+      doctor --strict` exits 3 with the expected `CLOCKIFY_POLICY`
+      error finding. Local `--check-backends` against the synthetic DSN
+      requires a real Postgres and is intentionally not closure
+      evidence; release-smoke's service-container run is the
+      authoritative `--check-backends` proof for this box._
 
 **Definition of done.** A clean checkout of the candidate tag
 produces a green `release-check`, every required workflow on

--- a/docs/launch-readiness-review-may-8.md
+++ b/docs/launch-readiness-review-may-8.md
@@ -781,9 +781,50 @@ prints a specific maintainer action beside each open gate.
   final candidate tag and evidence for `make verify-vuln`,
   `make verify-fips`, gitleaks, and semgrep/no-finding disposition.
   This is `L-04`.
-- **Group 7 release/sigstore/SLSA evidence.** Still requires an
-  actual `vX.Y.Z-rc.N` tag (`L-01`), release smoke, cosign/SLSA
-  verification, and archived `doctor --strict` output.
+- **Group 7 release/sigstore/SLSA evidence.** Partially closed on
+  2026-05-10 against rc.2 candidate SHA
+  `d83f9f86d3b95594abef2ee035554510faa799c1`. The two
+  artefact-and-doctor boxes are now closed in
+  `docs/launch-candidate-checklist.md`: release-smoke run
+  https://github.com/apet97/go-clockify/actions/runs/25613270137
+  verified cosign on `clockify-mcp-linux-x64` +
+  `clockify-mcp-postgres-linux-x64` + the multi-arch image at
+  `ghcr.io/apet97/go-clockify@sha256:4171a582016b55ae5365d626b697831c7146c7c3bed9cef134be91ef8083a3b5`,
+  succeeded on SLSA attestation verification for the same two
+  binaries (rc.2 attestations report
+  `sourceRepositoryVisibilityAtSigning="public"`, so the ADR-0013
+  user-owned-private feature gate did not trip), and uploaded the
+  `release-smoke-doctor-output` artifact with all three required
+  files. Local manual verification on darwin-arm64 reproduced
+  `Verified OK` for the FIPS variant
+  (`clockify-mcp-fips-linux-x64.sigstore.json`) and reproduced the
+  positive and negative `doctor --strict` cases from the
+  candidate-tag tree. The SLSA statement names all 15 binary
+  subjects with `builder.id =
+  https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/v1.2.1-rc.2`
+  and `runDetails.metadata.invocationId =
+  https://github.com/apet97/go-clockify/actions/runs/25613215490/attempts/1`.
+  Two Group 7 boxes remain open: `make release-check` on macOS
+  arm64 hits a pre-existing bash-3.2 trap in
+  `scripts/check-public-content-audit.sh:441` when invoked through
+  `bash -lc` (script not in this lane's allowed write set), and the
+  required-workflows row stays open because `reproducibility.yml`
+  run https://github.com/apet97/go-clockify/actions/runs/25613269789
+  failed on rc.2 with sha256 mismatches between local rebuilds and
+  published assets for `clockify-mcp-fips-linux-x64`,
+  `clockify-mcp-darwin-arm64`, `clockify-mcp-fips-darwin-arm64`,
+  and `clockify-mcp-fips-darwin-x64`. The rc.2 Deploy run
+  https://github.com/apet97/go-clockify/actions/runs/25613215498
+  also failed (NEW rc.2 finding): the `Verify Release Assets`
+  job's `gh release download` step lacks the retry budget that
+  PR #80 added for the cosign-verify step, and ran 9 seconds
+  before the GitHub Release object finished publishing
+  (download attempt 22:20:29Z, release publishedAt 22:20:38Z).
+  Release artefacts themselves are intact and verifiable by the
+  release-smoke run; this is a Deploy-pipeline race, not a
+  release-artifact regression. Both `reproducibility.yml` and
+  `deploy.yml` remain owned by other lanes; this lane only records
+  the findings.
 - **Launch-candidate tracking issue.** The coordinator's Day 2 plan
   requires opening `Launch candidate vX.Y.Z-rc.N` after the rc exists
   and linking every green workflow run, archived `doctor --strict`

--- a/docs/runbooks/release-candidate-evidence.md
+++ b/docs/runbooks/release-candidate-evidence.md
@@ -248,3 +248,131 @@ Why these are **not** transient and require an rc.2:
 3. **release-smoke not firing.** Architectural — `GITHUB_TOKEN`-suppressed event chain. The release.yml fix adds an explicit `gh workflow run release-smoke.yml --ref main -f tag=$RELEASE_VERSION` step after the existing `Trigger reproducibility verification` step (mirrors the same pattern reproducibility.yml uses for the same reason).
 
 rc.2 cuts only after the fix PR for these three issues lands on `main`. This runbook is updated again with the rc.2 evidence pointers when rc.2's Release / Docker Image / Deploy / release-smoke / npm-publish all complete green and the Group 7 evidence is recordable.
+
+## Evidence record — v1.2.1-rc.2 (2026-05-10)
+
+`v1.2.1-rc.2` was cut on annotated tag SHA
+`681079e571bed0efbfd448129a3d9fa1de58cd15` peeling to commit
+`d83f9f86d3b95594abef2ee035554510faa799c1` after PR #80 landed the
+three rc.1 fixes on `main`. Tag-driven workflows fired on
+2026-05-09T22:18:18Z. Local Group 6/7 evidence was collected on
+darwin-arm64 the same evening; Linux x64 release-check evidence is
+captured by the CI workflows referenced below rather than a second
+local host.
+
+### Workflow status on rc.2
+
+| Workflow | Run ID | Result | Notes |
+|---|---|---|---|
+| Release (goreleaser) | [25613215490](https://github.com/apet97/go-clockify/actions/runs/25613215490) | ✅ success | All 47 release assets uploaded between 22:20:29Z and 22:20:38Z (46 contracted assets per `scripts/check-release-assets.sh` plus one supplementary package-level SBOM whose name embeds the image digest `sha256:4171…3b5`). `dist-tags.rc=1.2.1-rc.2` published to npm via the `--tag rc` codepath introduced in `scripts/publish-npm.sh` for prereleases. |
+| Docker Image | [25613215492](https://github.com/apet97/go-clockify/actions/runs/25613215492) | ✅ success | Multi-arch image at `ghcr.io/apet97/go-clockify@sha256:4171a582016b55ae5365d626b697831c7146c7c3bed9cef134be91ef8083a3b5` with cosign signature + SBOM attestation. |
+| `release-smoke.yml` | [25613270137](https://github.com/apet97/go-clockify/actions/runs/25613270137) | ✅ success | Auto-fired by the new `Trigger release smoke verification` step in `release.yml` (workflow_dispatch with `tag=v1.2.1-rc.2`). Verified `cosign verify-blob` for `clockify-mcp-linux-x64` and `clockify-mcp-postgres-linux-x64` (both `Verified OK`), `gh attestation verify` for the same two binaries (SLSA), and `cosign verify ghcr.io/apet97/go-clockify@sha256:4171…3b5` for the image. Uploaded the `release-smoke-doctor-output` artifact (https://api.github.com/repos/apet97/go-clockify/actions/artifacts/6899048388/zip) with `release-doctor-strict-ok.txt`, `release-doctor-strict-fail.txt`, and `release-doctor-postgres-ok.txt`. |
+| Deploy | [25613215498](https://github.com/apet97/go-clockify/actions/runs/25613215498) | ❌ failure (NEW finding for rc.2) | `Verify Release Assets / Download release binary for SLSA verification` ran `gh release download` at 22:20:29Z and exited 1 (`release not found`). The release object did not finish publishing until 22:20:38Z (publishedAt). The PR #80 cosign-verify retry covers the cosign step but **does not** wrap the subsequent `gh release download` step, so a 9-second race between Deploy's verify job and Release's `gh release upload`/publish window now reproduces here. The release artefacts themselves are intact and verifiable (see release-smoke above); this is a Deploy-pipeline race, not a release-artifact regression. |
+| Reproducibility | [25613269789](https://github.com/apet97/go-clockify/actions/runs/25613269789) | ❌ failure (NEW finding for rc.2) | sha256 mismatches between local rebuilds and published assets for `clockify-mcp-fips-linux-x64` (local `01e1571…`, released `fac3b60…`), `clockify-mcp-darwin-arm64` (local `2e8a713…`, released `3b2ab4b…`), `clockify-mcp-fips-darwin-x64` (local `1b07aa4…`, released `c262a42…`), and `clockify-mcp-fips-darwin-arm64`. The cosign and SLSA chains still verify against the published bytes; the failure is reproducibility (bit-identical rebuild) rather than provenance. Most likely cause is a Go-toolchain or build-environment difference between the goreleaser linux runner and the per-asset rebuild matrix that rebuilds darwin/fips locally. Triage required before reproducibility.yml can return green on the candidate SHA. |
+
+The mutation cron line is unchanged from before rc.2: the latest
+scheduled `mutation.yml` run remains 25592823559 cancelled on the
+pre-rc.2 commit `4fe957547f9e6aea749a85f87823d17a0ccc2928`; a fresh
+cron pass on the rc.2 SHA is still required to close the
+required-workflows row in the launch checklist.
+
+### Local Group 6/7 evidence (darwin-arm64, candidate-tag tree)
+
+`scripts/prepare-rc-evidence.sh v1.2.1-rc.2` collected logs under
+`${TMPDIR}/go-clockify-rc-evidence/v1.2.1-rc.2/logs/darwin-arm64/`.
+Group 6 commands all passed:
+
+- `make check` — full test suite green.
+- `make verify-vuln` — `govulncheck@v1.3.0` under `GOTOOLCHAIN=go1.25.10`: `No vulnerabilities found.`
+- `make secret-scan` — `gitleaks` returned `no leaks found` against the candidate-tag tree.
+- Semgrep `p/default --metrics=off --error` — `Findings: 0 (0 blocking)`, 558 rules / 1155 targets.
+- `make verify-fips` — default + `-tags=fips,grpc` builds and tests passed under `GOTOOLCHAIN=go1.25.10`.
+
+Group 7 commands recorded one **environmental** local failure that is
+not a defect in the rc.2 candidate tree:
+
+- `make release-check` failed inside `make script-tests` when the
+  `bash $script` invocation in `scripts/test-check-public-content-audit.sh`
+  resolved to `/bin/bash 3.2` (Apple's system bash) rather than the
+  Homebrew-installed `bash 5.3`. macOS GNU bash 3.2 cannot parse the
+  `case` pattern inside the `$( … )` command substitution at
+  `scripts/check-public-content-audit.sh:441`
+  (`syntax error near unexpected token \`newline'`).
+  `make script-tests` invoked directly from the user's interactive
+  shell (PATH-resolved to bash 5.3) passes; `bash -lc "make
+  release-check"` from `prepare-rc-evidence.sh` uses bash 3.2 and
+  hits the syntax-error path. CI's macOS runners use a newer bash
+  and would not be subject to this trap. Recording here so future
+  candidate-tag macOS evidence collection knows to either set
+  `BASH=$(brew --prefix)/bin/bash` before invoking the script or
+  pass `bash --version`-aware shell hardening through the test
+  wrapper. The `check-public-content-audit.sh` script is outside
+  this lane's allowed write set; not modified here.
+- `bash scripts/check-launch-external-status.sh --candidate-sha
+  d83f9f86d3b95594abef2ee035554510faa799c1 --expected-npm-version
+  v1.2.1-rc.2 --fail-open` exits non-zero with `4 open, 0 unknown`.
+  Of the four open items, one is a known false-negative: the npm
+  predicate compares `dist-tags.latest` to the expected version, so
+  it reports `npm publish path: registry does not prove expected
+  release version 1.2.1-rc.2` even though `dist-tags.rc=1.2.1-rc.2`
+  is the correct prerelease tag (`dist-tags.latest` continues to
+  point at the v1.2.0 stable release as designed). The other three
+  open items (local branch cleanup, Group 1 SHA mismatch, mutation
+  cron) are pre-existing trackers per the launch checklist and the
+  Group 1 closure pin on `feef83c641ced93d2ab6ba07ef766d61c82cc703`.
+  The launch-external-status npm predicate is also outside this
+  lane's allowed write set; left as a documented finding.
+
+Local manual verification per `docs/verification.md`:
+
+- `cosign verify-blob --bundle clockify-mcp-linux-x64.sigstore.json
+  --certificate-identity-regexp
+  '^https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/.*$'
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  clockify-mcp-linux-x64` → `Verified OK`.
+- `cosign verify-blob --bundle clockify-mcp-fips-linux-x64.sigstore.json
+  …` (same identity regex) → `Verified OK`.
+- `gh attestation verify clockify-mcp-linux-x64 --owner apet97`
+  → exit 0; the SLSA statement names all 15 binary subjects with
+  `predicateType =
+  https://slsa.dev/provenance/v1`,
+  `builder.id =
+  https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/v1.2.1-rc.2`,
+  `runDetails.metadata.invocationId =
+  https://github.com/apet97/go-clockify/actions/runs/25613215490/attempts/1`,
+  and `sourceRepositoryDigest =
+  d83f9f86d3b95594abef2ee035554510faa799c1`. The cert SAN reports
+  `sourceRepositoryVisibilityAtSigning="public"`, so the
+  ADR-0013 user-owned-private feature gate did not trip on this rc.
+- `MCP_PROFILE=prod-postgres … /tmp/clockify-mcp-rc2 doctor --strict`
+  on a fresh local build of HEAD (`d83f9f8…`) → exit 0,
+  `Strict posture: OK no hosted-service findings`.
+- `CLOCKIFY_POLICY=standard … doctor --strict` (negative case) →
+  exit 3, `Strict posture: ERROR 1 error finding(s)`,
+  `CLOCKIFY_POLICY hosted strict posture requires CLOCKIFY_POLICY no
+  broader than time_tracking_safe`.
+
+### What rc.2 closes vs leaves open
+
+- **Closes (Group 7):** the release-artefact signing/SBOM/SLSA box
+  and the `doctor --strict` reference-deployment box, both backed
+  by the green release-smoke run plus the local manual verification
+  above.
+- **Stays open (Group 7):** `make release-check` on macOS arm64
+  (environmental bash 3.2 trap above) and the required-workflows row
+  (`reproducibility.yml` failed on rc.2 in addition to the still-open
+  `mutation.yml` cron). Per the operator non-goal, no other Group 7
+  box was ticked from this lane; Group 6 box closures remain a
+  separate lane on the candidate tag.
+
+### Operator handoff items (not changed by this lane)
+
+- The Deploy `gh release download` race is a real workflow defect
+  but `deploy.yml` is outside this lane's allowed write set. The
+  fix mirrors the cosign-verify retry pattern PR #80 introduced:
+  wrap `gh release download` in a 24×30s retry budget so the
+  Deploy verify job can ride out the Release publish window.
+- The reproducibility-bench failure should be triaged on a
+  follow-up by comparing `go version -m` between the goreleaser
+  linux runner output and the per-asset rebuild matrix output for
+  the FIPS/darwin variants.


### PR DESCRIPTION
## Summary

Records the v1.2.1-rc.2 Group 7 release/sigstore/SLSA evidence, ticks the two boxes the rc.2 evidence proves (release artefacts + reference-deployment doctor), and documents the rc.2-specific findings that keep the remaining Group 7 boxes open.

This PR does **NOT** declare the repo launch-ready. Group 6 (separate lane), the new rc.2 Deploy + Reproducibility findings noted below, the mutation cron, and the hosted/legal/product gates remain open. Issue #78 (19-context branch protection restoration) remains open by operator instruction.

## Tag and SHA

- Tag: `v1.2.1-rc.2`
- Annotated tag SHA: `681079e571bed0efbfd448129a3d9fa1de58cd15`
- Peeled commit SHA (= HEAD of this branch's base): `d83f9f86d3b95594abef2ee035554510faa799c1`

## Workflow status on rc.2

| Workflow | Run ID | Result | Notes |
|---|---|---|---|
| Release | [25613215490](https://github.com/apet97/go-clockify/actions/runs/25613215490) | ✅ success | All 47 release assets uploaded; npm publish landed `dist-tags.rc=1.2.1-rc.2` via the prerelease `--tag rc` codepath introduced by PR #80. |
| Docker Image | [25613215492](https://github.com/apet97/go-clockify/actions/runs/25613215492) | ✅ success | Multi-arch image at `ghcr.io/apet97/go-clockify@sha256:4171a582016b55ae5365d626b697831c7146c7c3bed9cef134be91ef8083a3b5`. |
| `release-smoke.yml` | [25613270137](https://github.com/apet97/go-clockify/actions/runs/25613270137) | ✅ success | Auto-fired on rc.2 via the new explicit `workflow_dispatch` trigger added to `release.yml` in PR #80. Verified cosign + SLSA + image cosign + `doctor --strict` artefacts. |
| Deploy | [25613215498](https://github.com/apet97/go-clockify/actions/runs/25613215498) | ❌ failure (NEW rc.2 finding) | `Verify Release Assets / Download release binary for SLSA verification` ran `gh release download` at 22:20:29Z, exited 1 (`release not found`). The release object's `publishedAt` is 22:20:38Z — a 9-second race. PR #80's cosign-verify retry budget covers cosign but **does not** wrap `gh release download`. Release artefacts themselves are intact and verifiable; this is a Deploy-pipeline race. |
| Reproducibility | [25613269789](https://github.com/apet97/go-clockify/actions/runs/25613269789) | ❌ failure (NEW rc.2 finding) | sha256 mismatches between local rebuilds and published assets for `clockify-mcp-fips-linux-x64`, `clockify-mcp-darwin-arm64`, `clockify-mcp-fips-darwin-arm64`, `clockify-mcp-fips-darwin-x64`. cosign and SLSA still verify against the published bytes — the failure is reproducibility (bit-identical rebuild), not provenance. Likely Go-toolchain/build-env divergence between the goreleaser linux runner and the per-asset rebuild matrix; needs triage. |

## GitHub Release object

`gh release view v1.2.1-rc.2 --repo apet97/go-clockify` reports:

- `name=v1.2.1-rc.2`, `tagName=v1.2.1-rc.2`, `targetCommitish=main`, `isDraft=false`, `isPrerelease=true`
- `publishedAt=2026-05-09T22:20:38Z`
- 47 assets total: 46 contracted assets per `scripts/check-release-assets.sh` + 1 supplementary package-level SBOM whose name embeds the image digest `sha256:4171…3b5`. `bash scripts/check-release-assets.sh <asset-list>` returns `OK: all 46 expected release assets present`.
- URL: https://github.com/apet97/go-clockify/releases/tag/v1.2.1-rc.2

## Sigstore / cosign / SLSA / SBOM verification

Local manual verification per `docs/verification.md`:

```
$ cosign verify-blob \
    --bundle clockify-mcp-linux-x64.sigstore.json \
    --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/.*$' \
    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
    clockify-mcp-linux-x64
Verified OK
```

```
$ cosign verify-blob \
    --bundle clockify-mcp-fips-linux-x64.sigstore.json \
    --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/.*$' \
    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
    clockify-mcp-fips-linux-x64
Verified OK
```

```
$ gh attestation verify clockify-mcp-linux-x64 --owner apet97
exit=0
# JSON summary: predicateType=https://slsa.dev/provenance/v1
# builder.id=https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/v1.2.1-rc.2
# runDetails.metadata.invocationId=https://github.com/apet97/go-clockify/actions/runs/25613215490/attempts/1
# sourceRepositoryRef=refs/tags/v1.2.1-rc.2
# sourceRepositoryDigest=d83f9f86d3b95594abef2ee035554510faa799c1
# sourceRepositoryVisibilityAtSigning=public  (ADR-0013 user-owned-private feature gate did not trip)
# binary subjects=15 (all default + FIPS + Postgres + gRPC + gRPC+Postgres binaries)
```

`release-smoke.yml` run [25613270137](https://github.com/apet97/go-clockify/actions/runs/25613270137) additionally verified, on Linux against the same rc.2 assets:

```
Install cosign … Verified OK
Verify cosign keyless signature on binary … Verified OK
Verify cosign keyless signature on Postgres binary … Verified OK
Verify cosign keyless signature on container image
  → OK: cosign verify ghcr.io/apet97/go-clockify@sha256:4171a582016b55ae5365d626b697831c7146c7c3bed9cef134be91ef8083a3b5
```

## doctor --strict evidence

`release-smoke.yml` uploaded the `release-smoke-doctor-output` artifact (`size=5716 bytes`, `expired=false`):
https://api.github.com/repos/apet97/go-clockify/actions/artifacts/6899048388/zip

It contains all three required files:

- `release-doctor-strict-ok.txt` — `Strict posture: OK no fatal findings; 1 warning(s)` for `clockify-mcp-linux-x64` under `MCP_PROFILE=prod-postgres`.
- `release-doctor-postgres-ok.txt` — `Strict posture: OK` for `clockify-mcp-postgres-linux-x64` against the workflow's Postgres service container (`--check-backends` succeeded).
- `release-doctor-strict-fail.txt` — `Strict posture: ERROR 1 error finding(s)`, `CLOCKIFY_POLICY` rejected when broader than `time_tracking_safe`.

Local doctor strict on the candidate-tag tree (HEAD `d83f9f8…`) reproduced both behaviours: `MCP_PROFILE=prod-postgres … doctor --strict` exits 0; `CLOCKIFY_POLICY=standard … doctor --strict` exits 3 with the expected `CLOCKIFY_POLICY` error finding.

## npm expected-version proof

`npm view @apet97/clockify-mcp-go version dist-tags --json`:

```
{
  "version": "1.2.0",
  "dist-tags": {
    "latest": "1.2.0",
    "rc": "1.2.1-rc.2"
  }
}
```

`dist-tags.rc=1.2.1-rc.2` confirms the prerelease publish path from PR #80 worked correctly. `dist-tags.latest` continues to point at the v1.2.0 stable release as designed.

`bash scripts/check-launch-external-status.sh --candidate-sha d83f9f86d3b95594abef2ee035554510faa799c1 --expected-npm-version v1.2.1-rc.2 --fail-open` returns `5 open, 0 unknown` (exit 1). The five open items are documented findings:

1. `working tree is dirty` — disappears after this commit lands.
2. `local branch cleanup` — pre-existing.
3. `Group 1: live-contract.yml runs do not prove two greens on d83f9f86…` — Group 1 closure is intentionally pinned to canonical SHA `feef83c641ced93d2ab6ba07ef766d61c82cc703` per operator instruction; do not conflate with rc.2.
4. `mutation.yml: latest scheduled run is not green on d83f9f86…` — pre-existing pending-cron tracker.
5. `npm publish path: registry does not prove expected release version 1.2.1-rc.2` — script bug: the predicate compares `dist-tags.latest` and `version`, not `dist-tags.rc`. The actual publish succeeded (`dist-tags.rc=1.2.1-rc.2` above). The script is outside this lane's allowed write set.

## What this PR closes vs leaves open

**Closed in `docs/launch-candidate-checklist.md` Group 7:**

- `[x]` Release artefacts: signed binaries (cosign + SLSA + SBOMs + Docker images + FIPS variant).
- `[x]` `clockify-mcp doctor --strict` and `clockify-mcp-postgres doctor --strict --check-backends` both exit 0 against the candidate's reference deployment.

**Stays open in Group 7 (this lane records, other lanes own):**

- `[ ]` `make release-check` green from a clean checkout on macOS arm64 — pre-existing bash 3.2 trap in `scripts/check-public-content-audit.sh:441` surfaces under `bash -lc` resolution. CI macOS would not be affected. Script is outside this lane's allowed write set.
- `[ ]` All required workflows on `main` green — `reproducibility.yml` failed on rc.2 in addition to the still-open `mutation.yml` cron.

**Other groups untouched:** Group 1 evidence stays closed on canonical SHA `feef83c6…`; Group 6 is a separate lane; issue #78 (19-context branch protection restoration) remains open.

## Verified

- `make doc-parity` → `doc-parity OK; launch-review-ledger OK; launch-checklist-parity OK; launch-evidence-gate OK`
- `make launch-checklist-parity` → `launch-checklist-parity OK; launch-evidence-gate OK`
- `bash scripts/check-launch-external-status.sh --candidate-sha d83f9f86d3b95594abef2ee035554510faa799c1 --expected-npm-version v1.2.1-rc.2 --fail-open` → `5 open, 0 unknown` (all five documented; see npm section above)
- `bash scripts/test-prepare-rc-evidence.sh` → `prepare-rc-evidence tests: 4 run, 0 failed`
- `bash scripts/test-check-release-assets.sh` → `check-release-assets tests: 10/10 OK` (includes the v0.7.0 SBOM-drop regression class)
- `bash scripts/test-publish-npm.sh` → `publish-npm tests: 7 run, 0 failed` (includes the rc.2 prerelease tag-derivation case)
- `git diff --check` → clean
- `gh attestation verify clockify-mcp-linux-x64 --owner apet97` → exit 0; SLSA statement above
- `cosign verify-blob` (linux-x64, fips-linux-x64) → both `Verified OK`
- `release-smoke` run 25613270137 → success on rc.2 inputs

## Test plan

- [ ] Confirm the four edited docs render correctly on the GitHub PR diff.
- [ ] Confirm `make doc-parity`, `make launch-checklist-parity` remain green at PR head.
- [ ] Sanity-check `bash scripts/check-launch-evidence-gate.sh` passes with the two newly-checked Group 7 boxes.
- [ ] Spot-check that the rc.2 evidence URLs (release object, release-smoke run, attestation API URL, image digest) resolve.