### PR TITLE
docs(launch): record Group 7 evidence for v1.2.1-rc.3

### DIFF
--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -71,32 +71,42 @@ work and commit it.
   probes are coverage evidence only and do not tick any external
   launch-evidence box.
 - **Open launch-evidence gates (not a complete blocker list):**
-  - **Candidate-tag security walk-through** — `v1.2.1-rc.3` (peeled
-    commit `ce56414ae012c4a49d21ae0a319b178619c5966a`) carries a
+  - **Candidate-tag security walk-through** — closed for
+    `v1.2.1-rc.3` (peeled commit
+    `ce56414ae012c4a49d21ae0a319b178619c5966a`) via PR #84. The
     fresh-worktree transcript of `make check`, `make verify-vuln`,
     `make secret-scan`, the canonical
     `semgrep scan --config p/default ...` invocation, the
-    `git grep -n -C 5 nosemgrep` enumeration, and `make verify-fips`,
-    captured on host short name `192` on 2026-05-10 between 01:55 UTC
-    and 01:59 UTC; full output is in [`SECURITY.md`](../SECURITY.md) §
-    "Candidate-tag security evidence" and the four candidate-tag-
-    dependent Group 6 boxes
+    `git grep -n -C 5 nosemgrep` enumeration, and `make verify-fips`
+    is captured on host short name `192` on 2026-05-10 between
+    01:55 UTC and 01:59 UTC; full output is in
+    [`SECURITY.md`](../SECURITY.md) § "Candidate-tag security
+    evidence" and the four candidate-tag-dependent Group 6 boxes
     (`make verify-vuln`, gitleaks, Semgrep, `make verify-fips`) in
     [`launch-candidate-checklist.md`](launch-candidate-checklist.md)
     are now ticked. Re-run the same suite on any future candidate tag.
-  - **Release/sigstore/SLSA evidence** — cut `vX.Y.Z-rc.N`, run
-    `release-smoke.yml`, verify sigstore + SLSA artefact
-    attestations, and archive the reference `doctor --strict`
-    outputs. `v1.2.1-rc.3` already published the GitHub Release
-    object with 47 assets and is_prerelease=true on 2026-05-10
-    01:47:39 UTC; tag-triggered Release run 25616879096, Docker
+  - **Release/sigstore/SLSA evidence** — partially closed
+    2026-05-10 for `v1.2.1-rc.3` (peeled commit `ce56414`). All
+    five tag-triggered + dispatched workflows on rc.3 completed
+    `success` in a single attempt: Release run 25616879096, Docker
     Image run 25616879055, Deploy run 25616879075, Reproducibility
     run 25616925376 (all 9 matrix jobs match released bytes), and
-    release-smoke run 25616925600 are green. Group 7 closure still
-    requires the per-host `release-check`, doctor-output
-    artifact archive, and the `check-launch-external-status`
-    `--expected-npm-version v1.2.1-rc.3 --fail-open` validator pass;
-    that work belongs to the separate Group 7 lane.
+    release-smoke run 25616925600. Manual cosign + SLSA + container
+    image verification passed against the documented certificate
+    identities (default linux-x64, postgres-linux-x64,
+    fips-linux-x64, darwin-arm64). The
+    `release-smoke-doctor-output` artifact is archived with all
+    three required `doctor --strict` files. The Group 7 release
+    artefact and doctor-strict checklist boxes are ticked. Two
+    Group 7 boxes remain open: `make release-check` from clean
+    checkouts on Linux x64 and macOS arm64 (this lane is
+    single-host darwin-arm64; macOS arm64 release-check itself
+    hit a transient TMPDIR script-tests race and reproduced
+    clean on re-run), and "All required workflows on `main`
+    green" (mutation.yml's next scheduled cron green on the
+    final candidate SHA is still pending). See
+    [`runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+    "v1.2.1-rc.3 evidence record".
 
 If a local-shell run of the live-contract suite reports `ok`
 suspiciously fast (≤ ~0.5s), the env-var gate
@@ -154,20 +164,43 @@ code/CI hardening backlog is tracked in
 1. **Candidate-tag security walk-through.** Local launch-review
    preflight was green on 2026-05-09 after moving to Go 1.25.10 and
    tagged `govulncheck@v1.3.0`. Closed for `v1.2.1-rc.3` on
-   2026-05-10: a fresh-worktree run on the rc.3 peeled commit
-   `ce56414ae012c4a49d21ae0a319b178619c5966a` (host short name `192`)
-   recorded `make check`, `make verify-vuln`, `make secret-scan`,
-   `semgrep scan --config p/default --metrics=off --error --exclude
-   .git --exclude .bench --exclude clockify-mcp .`,
+   2026-05-10 via PR #84: a fresh-worktree run on the rc.3 peeled
+   commit `ce56414ae012c4a49d21ae0a319b178619c5966a` (host short
+   name `192`) recorded `make check`, `make verify-vuln`,
+   `make secret-scan`, `semgrep scan --config p/default
+   --metrics=off --error --exclude .git --exclude .bench
+   --exclude clockify-mcp .`,
    `git grep -n -C 5 nosemgrep -- ':!CHANGELOG.md'`, and
    `make verify-fips` with explicit "no findings" evidence in
    [`SECURITY.md`](../SECURITY.md) § "Candidate-tag security
    evidence". Future candidate tags must re-run the same suite. The
    Semgrep workflow artifact still needs its first pushed-run
    evidence and does not replace the candidate-tag scan.
-2. **Release/sigstore/SLSA evidence.** The candidate tag still
-   needs `release-smoke.yml`, sigstore/SLSA/SBOM verification, and
-   archived `doctor --strict` outputs for the reference deployment.
+2. **Release/sigstore/SLSA evidence.** Partially closed 2026-05-10
+   for `v1.2.1-rc.3` (peeled commit
+   `ce56414ae012c4a49d21ae0a319b178619c5966a`). All five
+   tag-triggered + dispatched workflows on rc.3 completed
+   `success` in a single attempt: Release ([25616879096](https://github.com/apet97/go-clockify/actions/runs/25616879096)),
+   Docker Image ([25616879055](https://github.com/apet97/go-clockify/actions/runs/25616879055)),
+   Deploy ([25616879075](https://github.com/apet97/go-clockify/actions/runs/25616879075)),
+   Reproducibility ([25616925376](https://github.com/apet97/go-clockify/actions/runs/25616925376)),
+   release-smoke ([25616925600](https://github.com/apet97/go-clockify/actions/runs/25616925600)).
+   Manual `cosign verify-blob` + `gh attestation verify` succeeded
+   on the default linux-x64, postgres-linux-x64, fips-linux-x64,
+   and darwin-arm64 binaries; `cosign verify
+   ghcr.io/apet97/go-clockify:1.2.1-rc.3` (manifest digest
+   `sha256:374fbfb4bc18fd14a2fcd39fcae6c8da4054df3c162596ad476c15947b8a351f`)
+   passed against the docker-image.yml certificate identity. The
+   `release-smoke-doctor-output` artifact contains
+   `release-doctor-strict-ok.txt`,
+   `release-doctor-strict-fail.txt`, and
+   `release-doctor-postgres-ok.txt`. The two Group 7 boxes that
+   remain open are `make release-check` on Linux x64 + macOS
+   arm64 hosts and "All required workflows on `main` green"
+   (the next scheduled `mutation.yml` cron on the final candidate
+   SHA is still pending). See
+   [`runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+   "v1.2.1-rc.3 evidence record" for the full evidence list.
 3. **Externally visible repo-state cleanup.** Rechecked on 2026-05-09
    after `a07443b` landed: CodeQL run 25609129989, Dependency Review
    run 25609129978, and Semgrep run 25609129983 are green on the

--- a/docs/launch-candidate-checklist.md
+++ b/docs/launch-candidate-checklist.md
@@ -514,14 +514,52 @@ checked.
       25255062599, validated locally with `make bench-baseline-check`,
       then passed linux/amd64 comparison in
       https://github.com/apet97/go-clockify/actions/runs/25255216987._
-- [ ] Release artefacts: signed binaries (cosign, plus SLSA when
+- [x] Release artefacts: signed binaries (cosign, plus SLSA when
       GitHub artifact attestations are available), SBOMs,
       Docker images, FIPS variant. Verified by `release-smoke.yml`
       on the candidate tag for its sampled default/Postgres
       linux-x64 artifacts, plus manual `docs/verification.md`
       evidence for any required variant not sampled by
       `release-smoke.yml`.
-- [ ] `clockify-mcp doctor --strict` and
+      _Closed 2026-05-10 for `v1.2.1-rc.3` (peeled commit
+      `ce56414ae012c4a49d21ae0a319b178619c5966a`):
+      release.yml workflow_run_id: 25616879096,
+      https://github.com/apet97/go-clockify/actions/runs/25616879096;
+      docker-image.yml workflow_run_id: 25616879055,
+      https://github.com/apet97/go-clockify/actions/runs/25616879055;
+      reproducibility.yml workflow_run_id: 25616925376,
+      https://github.com/apet97/go-clockify/actions/runs/25616925376;
+      release-smoke.yml workflow_run_id: 25616925600,
+      https://github.com/apet97/go-clockify/actions/runs/25616925600
+      (all `success` in a single attempt). GitHub Release object:
+      https://github.com/apet97/go-clockify/releases/tag/v1.2.1-rc.3
+      (`isPrerelease=true`, `isDraft=false`, 47 assets — 15 binaries,
+      15 `.spdx.json` SBOMs, 15 `.sigstore.json` cosign bundles,
+      `SHA256SUMS.txt`, plus a goreleaser source-tree SBOM that the
+      published-asset regex in `scripts/check-release-assets.sh`
+      filters out of the 46-asset binary contract). Manual
+      verification with the documented commands from
+      [`docs/verification.md`](verification.md) reported
+      `Verified OK` (`cosign verify-blob` against the
+      `release.yml@refs/tags/v1.2.1-rc.3` certificate identity)
+      and `✓ Verification succeeded!`
+      (`gh attestation verify --owner apet97`) on the default
+      `clockify-mcp-linux-x64`, `clockify-mcp-postgres-linux-x64`,
+      `clockify-mcp-fips-linux-x64`, and the FIPS-non-sampled
+      `clockify-mcp-darwin-arm64` binaries. The single SLSA
+      in-toto statement covers all 15 binaries with their SHA256
+      digests; `predicate.buildDefinition.resolvedDependencies`
+      pins git commit `ce56414ae012c4a49d21ae0a319b178619c5966a`
+      and the builder ID is
+      `https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/v1.2.1-rc.3`.
+      `cosign verify ghcr.io/apet97/go-clockify:1.2.1-rc.3`
+      (manifest digest
+      `sha256:374fbfb4bc18fd14a2fcd39fcae6c8da4054df3c162596ad476c15947b8a351f`)
+      passed against the `docker-image.yml@refs/tags/.*`
+      certificate identity. `shasum -a 256 -c SHA256SUMS.txt
+      --ignore-missing` confirmed every downloaded binary and SBOM
+      matched the release-staged hashes._
+- [x] `clockify-mcp doctor --strict` and
       `clockify-mcp-postgres doctor --strict --check-backends`
       both exit 0 against the candidate's reference deployment.
       For `release-smoke.yml`, archive or link the
@@ -529,6 +567,25 @@ checked.
       `release-doctor-strict-ok.txt`,
       `release-doctor-strict-fail.txt`, and
       `release-doctor-postgres-ok.txt`.
+      _Closed 2026-05-10 for `v1.2.1-rc.3` (peeled commit
+      `ce56414ae012c4a49d21ae0a319b178619c5966a`):
+      release-smoke.yml workflow_run_id: 25616925600,
+      https://github.com/apet97/go-clockify/actions/runs/25616925600.
+      The `release-smoke-doctor-output` artifact contains all three
+      required files: `release-doctor-strict-ok.txt` exits 0 with
+      `Strict posture: OK no fatal findings; 1 warning(s)` for the
+      default `clockify-mcp-linux-x64` binary in the prod-postgres
+      profile; `release-doctor-strict-fail.txt` exits 3 with
+      `Strict posture: ERROR ... CLOCKIFY_POLICY` finding when
+      `CLOCKIFY_POLICY=standard` is set (the documented expected
+      fail); `release-doctor-postgres-ok.txt` exits 0 with
+      `Strict posture: OK` from the postgres-tagged
+      `clockify-mcp-postgres-linux-x64` binary running
+      `doctor --strict --check-backends` against a
+      `postgres:16-alpine` service container. Local re-verification
+      of the released `clockify-mcp-darwin-arm64` binary reproduced
+      both expected exits (0 with the documented `prod-postgres`
+      env shape; 3 with `CLOCKIFY_POLICY=standard`)._
 
 **Definition of done.** A clean checkout of the candidate tag
 produces a green `release-check`, every required workflow on

--- a/docs/launch-readiness-review-may-8.md
+++ b/docs/launch-readiness-review-may-8.md
@@ -778,7 +778,7 @@ prints a specific maintainer action beside each open gate.
   pass documents the operator coordination rule but does not change
   branch protection, push permissions, or any remote settings.
 - **Group 6 candidate-tag security walk-through.** Closed for
-  `v1.2.1-rc.3` on 2026-05-10. The annotated tag SHA is
+  `v1.2.1-rc.3` on 2026-05-10 via PR #84. The annotated tag SHA is
   `8f245174ca3567104a05a65a66250f0a10e5d486` and the peeled commit is
   `ce56414ae012c4a49d21ae0a319b178619c5966a`; tag-triggered Release
   run 25616879096, Docker Image run 25616879055, Deploy run
@@ -806,14 +806,41 @@ prints a specific maintainer action beside each open gate.
   (`make verify-vuln`, gitleaks, Semgrep, `make verify-fips`) carry
   matching `_Closed 2026-05-10 for v1.2.1-rc.3_` annotations. This is
   `L-04`. This closure does **not** declare the repository
-  launch-ready and does **not** close Group 7 release/sigstore/SLSA
-  evidence (separate lane), the mutation cron evidence, the npm
+  launch-ready and does **not** close the Group 7 two-host
+  release-check evidence, the mutation cron evidence, the npm
   expected-version proof, the paid-hosted external security review,
   the DPA / privacy / trademark gates, or issue #78 (19-context
   branch-protection restoration), all of which remain open.
-- **Group 7 release/sigstore/SLSA evidence.** Still requires an
-  actual `vX.Y.Z-rc.N` tag (`L-01`), release smoke, cosign/SLSA
-  verification, and archived `doctor --strict` output.
+- **Group 7 release/sigstore/SLSA evidence.** Partially closed
+  2026-05-10 for `v1.2.1-rc.3` (peeled commit
+  `ce56414ae012c4a49d21ae0a319b178619c5966a`): release.yml
+  ([25616879096](https://github.com/apet97/go-clockify/actions/runs/25616879096)),
+  docker-image.yml
+  ([25616879055](https://github.com/apet97/go-clockify/actions/runs/25616879055)),
+  deploy.yml
+  ([25616879075](https://github.com/apet97/go-clockify/actions/runs/25616879075)),
+  reproducibility.yml
+  ([25616925376](https://github.com/apet97/go-clockify/actions/runs/25616925376)),
+  and release-smoke.yml
+  ([25616925600](https://github.com/apet97/go-clockify/actions/runs/25616925600))
+  all completed `success` in a single attempt; manual
+  `cosign verify-blob` + `gh attestation verify` passed against
+  the documented `release.yml@refs/tags/v1.2.1-rc.3` certificate
+  identity for the default linux-x64, postgres-linux-x64,
+  fips-linux-x64, and darwin-arm64 binaries; `cosign verify
+  ghcr.io/apet97/go-clockify:1.2.1-rc.3` passed against the
+  docker-image.yml certificate identity (manifest digest
+  `sha256:374fbfb4bc18fd14a2fcd39fcae6c8da4054df3c162596ad476c15947b8a351f`);
+  the `release-smoke-doctor-output` artifact contains the three
+  required `doctor --strict` files. The Group 7 release-artefacts
+  and doctor-strict checklist boxes are ticked. The remaining
+  open Group 7 boxes are `make release-check` from clean
+  checkouts on Linux x64 + macOS arm64 hosts (`L-01` two-host
+  evidence) and "All required workflows on `main` green"
+  (`G-04` mutation.yml's next scheduled cron green on the final
+  candidate SHA is still pending). Full evidence list is in
+  [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+  "v1.2.1-rc.3 evidence record".
 - **Launch-candidate tracking issue.** The coordinator's Day 2 plan
   requires opening `Launch candidate vX.Y.Z-rc.N` after the rc exists
   and linking every green workflow run, archived `doctor --strict`

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -134,9 +134,14 @@ All binaries are built with `-trimpath`. Every binary ships:
 Plus, per release tag:
 
 - A multi-arch container image at
-  `ghcr.io/apet97/go-clockify:v<version>` carrying a cosign signature,
-  SPDX SBOM attestation, and SLSA build provenance attestation when
-  GitHub's attestation service is available.
+  `ghcr.io/apet97/go-clockify:<version>` (bare semver, no `v`
+  prefix — e.g. `:1.2.1-rc.3` for tag `v1.2.1-rc.3`), plus a
+  `:v<major>.<minor>` minor-line alias and a `:sha-<long-sha>` tag,
+  carrying a cosign signature, SPDX SBOM attestation, and SLSA build
+  provenance attestation when GitHub's attestation service is
+  available. The published-tag shape comes from `docker-image.yml`'s
+  `docker/metadata-action` config (`type=semver,pattern={{version}}`
+  plus `type=semver,pattern=v{{major}}.{{minor}}`).
 - An npm wrapper package (publish gated on `NPM_TOKEN` being set).
 - An unsigned `SHA256SUMS.txt` listing every binary in the release.
   Each row lets `sha256sum -c` cross-check a downloaded binary

--- a/docs/runbooks/release-candidate-evidence.md
+++ b/docs/runbooks/release-candidate-evidence.md
@@ -265,3 +265,49 @@ The Group 6 candidate-tag security walk-through ran on a clean fresh worktree of
 | `make verify-fips` | 0 | `-tags=fips` (GOFIPS140=latest) emitted `INFO fips140_enabled` before every package test passed; `-tags=fips,grpc` build combination green. |
 
 This evidence closed the four candidate-tag-dependent boxes in the Group 6 row of [`docs/launch-candidate-checklist.md`](../launch-candidate-checklist.md) (`make verify-vuln`, gitleaks, Semgrep, `make verify-fips`) for `v1.2.1-rc.3`. The full transcript is preserved in [`../../SECURITY.md`](../../SECURITY.md) § "Candidate-tag security evidence". This entry records Group 6 only; Group 7 (release/sigstore/SLSA per-host `release-check`, doctor-output artifact archive, and `check-launch-external-status --expected-npm-version v1.2.1-rc.3 --fail-open`) remains the separate Group 7 lane and is not closed by this record. The mutation cron evidence, the next-release npm expected-version proof, the paid-hosted external security review, the DPA / privacy / trademark gates, and issue #78 (19-context branch-protection restoration) are also unaffected by this record and remain open.
+## v1.2.1-rc.3 evidence record (2026-05-10)
+
+`v1.2.1-rc.3` was cut from peeled commit `ce56414ae012c4a49d21ae0a319b178619c5966a` (annotated tag SHA `8f245174ca3567104a05a65a66250f0a10e5d486`). Unlike rc.1 (preserved as failed-evidence-only because of the npm prerelease `--tag` bug, the Deploy cosign timing race, and release-smoke not auto-firing) and rc.2 (preserved as failed-Group-7-evidence-only because of the Deploy `gh release download` race and the Reproducibility `vcs.modified` mismatch), every tag-triggered and dispatched workflow on rc.3 completed `success` in a single attempt:
+
+| Workflow | Run ID | Result |
+|---|---|---|
+| Release (goreleaser) | [25616879096](https://github.com/apet97/go-clockify/actions/runs/25616879096) | ✅ success |
+| Docker Image | [25616879055](https://github.com/apet97/go-clockify/actions/runs/25616879055) | ✅ success |
+| Deploy | [25616879075](https://github.com/apet97/go-clockify/actions/runs/25616879075) | ✅ success |
+| Reproducibility (workflow_dispatch from release.yml) | [25616925376](https://github.com/apet97/go-clockify/actions/runs/25616925376) | ✅ success (9-job matrix; all jobs match released bytes) |
+| release-smoke (workflow_dispatch from release.yml) | [25616925600](https://github.com/apet97/go-clockify/actions/runs/25616925600) | ✅ success |
+
+GitHub Release: <https://github.com/apet97/go-clockify/releases/tag/v1.2.1-rc.3> (`name=v1.2.1-rc.3`, `tagName=v1.2.1-rc.3`, `isPrerelease=true`, `isDraft=false`, `createdAt=2026-05-10T01:45:25Z`, `publishedAt=2026-05-10T01:47:39Z`, 47 release assets — 15 binaries + 15 SPDX SBOMs + 15 sigstore bundles + `SHA256SUMS.txt` + 1 goreleaser source-tree SBOM named `apet97-go-clockify_sha256_<source-archive-sha256>.spdx.json` (the `<source-archive-sha256>` for rc.3 is `374fbfb4bc18fd14a2fcd39fcae6c8da4054df3c162596ad476c15947b8a351f`, which also matches the `ghcr.io/apet97/go-clockify:1.2.1-rc.3` image manifest digest)). The 46-asset binary contract enforced by `scripts/check-release-assets.sh` covers everything except the source-tree SBOM, which is filtered out by the published-asset-name regex.
+
+Local evidence run from the rc.3 worktree (`scripts/prepare-rc-evidence.sh v1.2.1-rc.3` from `opus/group7-release-rc3-20260510` HEAD `ce56414`):
+
+- Evidence directory: `${TMPDIR:-/tmp}/go-clockify-rc-evidence/v1.2.1-rc.3/logs/darwin-arm64/`.
+- Group 6 commands captured: `make check`, `make verify-vuln` (`govulncheck@v1.3.0` on Go 1.25.10 — `No vulnerabilities found.`), `make secret-scan` (gitleaks — `no leaks found`), Semgrep `p/default` scan, `git grep nosemgrep`, `make verify-fips` (`-tags=fips` and `-tags=fips,grpc` both green on a FIPS-capable Go 1.25.10 toolchain). These logs are Group 6 inputs and remain authoritative only for the Group 6 lane.
+- Group 7 `make release-check` log captured for the macOS arm64 host; the script-tests subroutine hit a transient TMPDIR concurrency failure on first invocation (parallel `mktemp` under `${TMPDIR}/test-public-content-audit-*`) and reproduced clean on re-run (`make script-tests` exits 0 with all per-test counts at `0 failed`). Re-running on a host with no concurrent TMPDIR consumers is the documented workaround; no script change is required.
+
+Group 7 release-evidence verifications run with the documented commands from [`docs/verification.md`](../verification.md) against the released asset bundle (default `clockify-mcp-linux-x64`, `clockify-mcp-postgres-linux-x64`, `clockify-mcp-fips-linux-x64`, `clockify-mcp-darwin-arm64`):
+
+- `cosign verify-blob --bundle <binary>.sigstore.json --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/.*$' --certificate-oidc-issuer https://token.actions.githubusercontent.com <binary>` reported `Verified OK` for all four binaries.
+- `gh attestation verify <binary> --owner apet97` reported `✓ Verification succeeded!` for all four binaries; the single SLSA in-toto statement covers all 15 binaries with their SHA256 digests; the predicate's `sourceRepositoryDigest` is `ce56414ae012c4a49d21ae0a319b178619c5966a` and the builder ID is `https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/v1.2.1-rc.3`.
+- `cosign verify ghcr.io/apet97/go-clockify:1.2.1-rc.3 --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/docker-image.yml@refs/tags/.*$' --certificate-oidc-issuer https://token.actions.githubusercontent.com` passed against image manifest digest `sha256:374fbfb4bc18fd14a2fcd39fcae6c8da4054df3c162596ad476c15947b8a351f`. The published container image tag is bare semver (`ghcr.io/apet97/go-clockify:1.2.1-rc.3`), not v-prefixed; the `docker-image.yml` `metadata-action` config uses `type=semver,pattern={{version}}`.
+- `shasum -a 256 -c SHA256SUMS.txt --ignore-missing` confirmed every downloaded binary and SBOM matched the release-staged hashes.
+- `release-smoke-doctor-output` artifact downloaded from run 25616925600: `release-doctor-strict-ok.txt` exits 0 with `Strict posture: OK no fatal findings; 1 warning(s)` (default linux-x64 binary, prod-postgres profile); `release-doctor-strict-fail.txt` exits 3 with the documented `Strict posture: ERROR ... CLOCKIFY_POLICY` finding when `CLOCKIFY_POLICY=standard` is set; `release-doctor-postgres-ok.txt` exits 0 with `Strict posture: OK` from the postgres-tagged linux-x64 binary running `doctor --strict --check-backends` against a `postgres:16-alpine` service container.
+- Local re-verification of `clockify-mcp-darwin-arm64` from the released asset bundle reproduced both expected doctor strict exits (0 with the documented `prod-postgres` env shape; 3 with `CLOCKIFY_POLICY=standard`).
+
+External-status snapshot (read-only) on the candidate SHA:
+
+```sh
+scripts/check-launch-external-status.sh \
+  --candidate-sha ce56414ae012c4a49d21ae0a319b178619c5966a \
+  --expected-npm-version v1.2.1-rc.3 \
+  --fail-open
+```
+
+Reports `4 open, 0 unknown` against `ce56414`:
+
+- `local branch cleanup`: 14 non-main local branches require maintainer disposition (worktree-active branches plus the historical `docs/document-f3897b2-bypass` and `fwbranch` holds; outside Group 7 scope).
+- `Group 1`: latest scheduled live-contract evidence is bound to the Group 1 SHA `feef83c641ced93d2ab6ba07ef766d61c82cc703` rather than the rc.3 SHA `ce56414`. Group 1 closure stays archived on `feef83c` per the May 9 evidence record; the verifier's per-SHA Group 1 check is a separate workstream.
+- `mutation.yml`: latest scheduled run 25592823559 still `completed/cancelled` on pushed commit `4fe957547f9e6aea749a85f87823d17a0ccc2928` because that scheduled cron fired before the `internal/tools` matrix-leg timeout fix (`2e7b6bd`) landed. The Group 7 "All required workflows on `main` green" box stays open until the next scheduled `mutation.yml` cron records green on the final candidate SHA.
+- `npm publish path: registry does not prove expected release version 1.2.1-rc.3`: the verifier's check matches `dist-tags.latest` (designed for stable releases) and ignores `dist-tags.rc`. `npm view @apet97/clockify-mcp-go --json` shows `dist-tags = {"latest":"1.2.0","rc":"1.2.1-rc.3"}` — the expected prerelease shape (`rc` dist-tag bumped, `latest` unchanged because the publish path correctly used `--tag rc` for the prerelease per the rc.2 fix in PR #80). The npm prerelease publish path is therefore proven; closing the verifier's recognition of prerelease dist-tags is a follow-up outside this lane's allow-list.
+
+Group 7 boxes that closed on this evidence: the **Release artefacts** box (sigstore + SLSA + SBOMs + container image) and the **`clockify-mcp doctor --strict`** box (release-smoke-doctor-output artifact + local re-verification). Group 7 boxes that remain open: **`make release-check` from clean checkouts on Linux x64 + macOS arm64** (this lane is single-host darwin-arm64 only and the macOS arm64 release-check itself transient-failed on the first invocation), and **All required workflows on `main` green** (mutation.yml's next scheduled cron green on the final candidate SHA is still pending).

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -131,7 +131,12 @@ by `release.yml`. The certificate identity differs accordingly.
 TAG=v1.2.0
 OWNER=apet97
 REPO="${OWNER}/go-clockify"
-IMAGE_REF="ghcr.io/${REPO}:${TAG}"
+# Container tags use bare semver (no `v` prefix). For tag `vX.Y.Z`,
+# the published image is at `ghcr.io/${REPO}:X.Y.Z`. The release
+# pipeline also publishes a `:v<major>.<minor>` alias and a
+# `:sha-<long-sha>` tag (see `docker-image.yml` metadata-action).
+IMAGE_TAG="${TAG#v}"
+IMAGE_REF="ghcr.io/${REPO}:${IMAGE_TAG}"
 
 cosign verify "$IMAGE_REF" \
   --certificate-identity-regexp "^https://github.com/${REPO}/.github/workflows/docker-image.yml@refs/tags/.*$" \

--- a/scripts/test-check-launch-evidence-gate.sh
+++ b/scripts/test-check-launch-evidence-gate.sh
@@ -124,12 +124,30 @@ else
 fi
 
 # ── Test 8: Group 6 box checked without evidence => FAIL ────────────
+#
+# After v1.2.1-rc.3 closures, the real Group 6 verify-vuln box is
+# already `[x]` with evidence on main, so the historical
+# `[ ]` -> `[x]` substitution against the real checklist became a
+# no-op. Construct a minimal synthetic checklist instead — a checked
+# Group 6 box with no evidence text within 8 lines — so the negative
+# test's invariant ("checked Group 6 box without evidence URL or
+# _Closed_ annotation must fail the gate") stays load-bearing
+# regardless of the real checklist's state.
 
 echo "== Test 8: Group 6 box checked without evidence => FAIL"
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
-sed 's/^- \[ \] `make verify-vuln` green for the candidate tag/- [x] `make verify-vuln` green for the candidate tag/' \
-  "$real_checklist" > "$tmp"
+cat > "$tmp" <<'EOF'
+# Launch candidate checklist — synthetic fixture for evidence-gate test 8
+
+## 6. Security and policy review
+
+- [x] `make verify-vuln` green for the candidate tag (govulncheck).
+
+## 7. CI / release readiness
+
+- [ ] All required workflows on `main` green: `ci.yml`, `codeql.yml`,
+EOF
 if LAUNCH_CHECKLIST="$tmp" bash "$script" >/dev/null 2>&1; then
   fail "Group 6 checked box without evidence should fail but exited 0"
 else
@@ -137,12 +155,25 @@ else
 fi
 
 # ── Test 9: Group 7 release-artifact box checked without evidence => FAIL ──
+#
+# Same pattern as Test 8: the real Release-artefacts box is now `[x]`
+# with evidence after Lane 3's rc.3 closure, so the historical
+# `[ ]` -> `[x]` substitution is a no-op. Use a synthetic minimal
+# fixture so the gate's "release-artifact checked without evidence"
+# negative test stays meaningful.
 
 echo "== Test 9: Group 7 release-artifact box checked without evidence => FAIL"
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
-sed 's/^- \[ \] Release artefacts: signed binaries (cosign, plus SLSA when/- [x] Release artefacts: signed binaries (cosign, plus SLSA when/' \
-  "$real_checklist" > "$tmp"
+cat > "$tmp" <<'EOF'
+# Launch candidate checklist — synthetic fixture for evidence-gate test 9
+
+## 7. CI / release readiness
+
+- [x] Release artefacts: signed binaries (cosign, plus SLSA when GitHub artifact attestations are available), SBOMs, container image, and SHA256SUMS.txt are all present on the GitHub Release.
+
+- [ ] All required workflows on `main` green: `ci.yml`, `codeql.yml`,
+EOF
 if LAUNCH_CHECKLIST="$tmp" bash "$script" >/dev/null 2>&1; then
   fail "Group 7 release-artifact box without evidence should fail but exited 0"
 else


### PR DESCRIPTION
## Summary

Tick the Group 7 release-artefacts and `clockify-mcp doctor --strict` checklist boxes for `v1.2.1-rc.3` and append a "v1.2.1-rc.3 evidence record" to `docs/runbooks/release-candidate-evidence.md` next to the rc.1 failed-evidence entry. Thread the closure through `docs/agent-handoff.md` and `docs/launch-readiness-review-may-8.md`. Fix two doc drifts (container image tag is bare semver, not `v`-prefixed) surfaced by the manual verification commands.

## Tag and SHA

- Tag: `v1.2.1-rc.3`
- Annotated tag SHA: `8f245174ca3567104a05a65a66250f0a10e5d486`
- Peeled commit SHA: `ce56414ae012c4a49d21ae0a319b178619c5966a` (= `main` HEAD before this PR)

## Workflow runs (all `success` in a single attempt)

| Workflow | Run ID | URL | Conclusion |
|---|---|---|---|
| Release (goreleaser) | 25616879096 | https://github.com/apet97/go-clockify/actions/runs/25616879096 | success |
| Docker Image | 25616879055 | https://github.com/apet97/go-clockify/actions/runs/25616879055 | success |
| Deploy | 25616879075 | https://github.com/apet97/go-clockify/actions/runs/25616879075 | success |
| Reproducibility (workflow_dispatch) | 25616925376 | https://github.com/apet97/go-clockify/actions/runs/25616925376 | success (9-job matrix; all jobs match released bytes) |
| release-smoke (workflow_dispatch) | 25616925600 | https://github.com/apet97/go-clockify/actions/runs/25616925600 | success |

## GitHub Release object

- URL: https://github.com/apet97/go-clockify/releases/tag/v1.2.1-rc.3
- `name=v1.2.1-rc.3`, `tagName=v1.2.1-rc.3`, `isPrerelease=true`, `isDraft=false`
- `createdAt=2026-05-10T01:45:25Z`, `publishedAt=2026-05-10T01:47:39Z`
- 47 release assets: 15 binaries + 15 SPDX SBOMs + 15 sigstore bundles + `SHA256SUMS.txt` + 1 goreleaser source-tree SBOM. The 46-asset binary contract enforced by `scripts/check-release-assets.sh` covers everything except the source-tree SBOM, which is filtered out by the published-asset-name regex.

## Cosign + SLSA + container image verification (manual, against released asset bundle)

Default `clockify-mcp-linux-x64`, `clockify-mcp-postgres-linux-x64`, `clockify-mcp-fips-linux-x64`, and the FIPS-non-sampled `clockify-mcp-darwin-arm64` were verified with the documented commands in `docs/verification.md`:

```
cosign verify-blob --bundle <binary>.sigstore.json \
  --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/.*$' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  <binary>
```

→ `Verified OK` for all four binaries.

```
gh attestation verify <binary> --owner apet97
```

→ `✓ Verification succeeded!` for all four binaries. The single SLSA in-toto statement covers all 15 binaries with their SHA256 digests; `predicate.buildDefinition.resolvedDependencies` pins git commit `ce56414ae012c4a49d21ae0a319b178619c5966a` and the builder ID is `https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/v1.2.1-rc.3`.

```
cosign verify ghcr.io/apet97/go-clockify:1.2.1-rc.3 \
  --certificate-identity-regexp '^https://github.com/apet97/go-clockify/.github/workflows/docker-image.yml@refs/tags/.*$' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

→ passed against image manifest digest `sha256:374fbfb4bc18fd14a2fcd39fcae6c8da4054df3c162596ad476c15947b8a351f`. Note: the published image tag is bare semver (`:1.2.1-rc.3`), not `v`-prefixed; PR fixes `docs/release-policy.md` and `docs/verification.md` to match.

```
shasum -a 256 -c SHA256SUMS.txt --ignore-missing
```

→ all downloaded binaries and SBOMs match the release-staged hashes.

## SBOM links

- Per-binary SBOMs: 15 `.spdx.json` assets attached to the GitHub Release (one per binary, e.g. https://github.com/apet97/go-clockify/releases/download/v1.2.1-rc.3/clockify-mcp-linux-x64.spdx.json).
- Source-tree SBOM: `apet97-go-clockify_sha256_<source-archive-sha256>.spdx.json` on the GitHub Release.
- Container image SPDX is attached as a cosign attestation; inspect with `cosign download attestation ghcr.io/apet97/go-clockify:1.2.1-rc.3 --predicate-type https://spdx.dev/Document`.

## Doctor `--strict` evidence (release-smoke artifact)

Downloaded `release-smoke-doctor-output` from run 25616925600. The artifact contains the three required files:

- `release-doctor-strict-ok.txt` — exit 0, `Strict posture: OK no fatal findings; 1 warning(s)` (default linux-x64 binary, prod-postgres profile).
- `release-doctor-strict-fail.txt` — exit 3, `Strict posture: ERROR ... CLOCKIFY_POLICY` finding when `CLOCKIFY_POLICY=standard` is set (the documented expected fail).
- `release-doctor-postgres-ok.txt` — exit 0, `Strict posture: OK` from the postgres-tagged linux-x64 binary running `doctor --strict --check-backends` against a `postgres:16-alpine` service container.

Local re-verification of the released `clockify-mcp-darwin-arm64` binary reproduced both expected exits (0 with the documented `prod-postgres` env shape; 3 with `CLOCKIFY_POLICY=standard`).

## npm expected-version verifier output

```
npm view @apet97/clockify-mcp-go --json | jq '.["dist-tags"]'
{
  "latest": "1.2.0",
  "rc": "1.2.1-rc.3"
}
```

This is the expected prerelease publish shape: `rc` dist-tag bumped to `1.2.1-rc.3`, `latest` unchanged. PR #80's `--tag rc` fix is observable on the registry.

```
bash scripts/check-launch-external-status.sh \
  --candidate-sha ce56414ae012c4a49d21ae0a319b178619c5966a \
  --expected-npm-version v1.2.1-rc.3 --fail-open
```

Exits non-zero with `4 open, 0 unknown` after this PR lands:

- `local branch cleanup`: 14 non-main local branches require maintainer disposition (worktree-active branches plus historical bypass holds; outside Group 7 scope).
- `Group 1`: latest scheduled live-contract evidence is bound to the Group 1 SHA `feef83c641ced93d2ab6ba07ef766d61c82cc703`, not the rc.3 SHA. Group 1 closure stays archived on `feef83c` per the May 9 evidence record.
- `mutation.yml`: latest scheduled run 25592823559 still `completed/cancelled` on commit `4fe9575` because that scheduled cron fired before the `internal/tools` matrix-leg timeout fix landed in `2e7b6bd`. Group 7 "All required workflows on `main` green" stays open until the next scheduled `mutation.yml` cron records green on the final candidate SHA.
- `npm publish path: registry does not prove expected release version 1.2.1-rc.3`: the verifier's check matches `dist-tags.latest` (designed for stable releases) and ignores `dist-tags.rc`. The rc publish path is proven via `dist-tags.rc=1.2.1-rc.3`; closing the verifier's recognition of prerelease dist-tags is a follow-up outside this lane's allow-list.

## Group 7 boxes that closed on this evidence

- ✅ **Release artefacts** (signed binaries, SBOMs, Docker images, FIPS variant): every required attestation verified locally with the documented commands; `release-smoke.yml` green for the sampled defaults.
- ✅ **`clockify-mcp doctor --strict`**: `release-smoke-doctor-output` artifact archived with the three required files; local re-verification reproduced the exits.

## Group 7 boxes that remain open

- ❌ **`make release-check` from clean checkouts on Linux x64 + macOS arm64**: this lane is single-host darwin-arm64 only; macOS arm64 release-check itself transient-failed once on a TMPDIR script-tests race and reproduced clean on re-run, but the Linux x64 host evidence is not collectible from this lane.
- ❌ **All required workflows on `main` green**: `mutation.yml` next scheduled cron green on the final candidate SHA is still pending.

## Doc drift fixes

- `docs/release-policy.md`: container image tag was documented as `v<version>`; actual published tag is bare semver. Updated to the real shape (`<version>`) plus the `:v<major>.<minor>` and `:sha-<long-sha>` aliases.
- `docs/verification.md`: section 3 example built `IMAGE_REF` as `${TAG}` (would be `v1.2.0`); the actual published tag strips the `v`. Added an `IMAGE_TAG="${TAG#v}"` line and a comment about the alias tags.

## Test plan

- [x] `make doc-parity` (doc-parity OK; launch-review-ledger OK; launch-checklist-parity OK; launch-evidence-gate OK).
- [x] `make launch-checklist-parity`.
- [x] `bash scripts/test-prepare-rc-evidence.sh` — 4 run, 0 failed.
- [x] `bash scripts/test-check-release-assets.sh` — 10/10 OK (covers v0.7.0-class missing-SBOM regression, missing-sigstore, missing-windows, missing-SHA256SUMS, rogue-asset, and -grpc-postgres count cases).
- [x] `bash scripts/test-publish-npm.sh` — 7 run, 0 failed.
- [x] `bash scripts/check-launch-external-status.sh --candidate-sha ce56414ae012c4a49d21ae0a319b178619c5966a --expected-npm-version v1.2.1-rc.3 --fail-open` exits non-zero with the documented 4 open gates after this PR lands.
- [x] `git diff --check` clean.
- [x] Each Group 7 closure annotation carries `workflow_run_id`, the GitHub Actions URL, and a `_Closed 2026-05-10` date so `scripts/check-launch-evidence-gate.sh` accepts the box change.

## Cross-references

- Held PRs: #82 (rc.2 Group 7 partial evidence) is held by the operator and not modified by this PR.
- Related PRs: #80 (rc.2 readiness — npm `--tag rc`, Deploy cosign retry, release-smoke trigger) and #83 (rc.3 readiness — release-download race + reproducibility GOWORK mismatch) landed the upstream fixes that made every rc.3 workflow green in a single attempt.
- Issue #78 (19-context branch-protection restoration follow-up) remains open by operator instruction.

## Non-claim

This PR does NOT declare the repo launch-ready. Group 6 (separate lane), mutation cron, hosted/legal/product gates remain open. Issue #78 (19-context branch protection restoration) remains open by operator instruction. Lane 6 final integration is held until both Group 6 and Group 7 evidence land on `main`.