### PR TITLE
docs(launch): record mutation cron post-fix evidence (run 25620978280)

### DIFF
--- a/docs/launch-readiness-review-may-8.md
+++ b/docs/launch-readiness-review-may-8.md
@@ -1225,6 +1225,7 @@ Lane 6 does not close them.
 | `CLOCKIFY_LIVE_AUDIT_REQUIRED` repo variable | `true`, last updated 2026-05-02T00:35:41Z (verified 2026-05-10 via `make launch-external-status`). |
 | Branch protection on `main` carries the three D9 launch checks | Re-applied 2026-05-09 with `Doctor strict smoke`, `Doctor Postgres backend`, and `Shared-service Postgres E2E` required (strict up-to-date, linear history, conversation resolution, no force push, no deletion). |
 | Issue #78 — restore the historical 19-context required-status list on `main` | Closed 2026-05-10 after the 21-context branch-protection restoration landed (additive PUT against `repos/apet97/go-clockify/branches/main/protection`). The classic `required_status_checks.contexts` array now carries the historical 18 plus the three D9 launch checks (`Doctor strict smoke`, `Doctor Postgres backend`, `Shared-service Postgres E2E`); `scripts/audit-branch-protection.sh` confirms the live state matches the documented snapshot in [`branch-protection.md`](branch-protection.md). |
+| Group 7 — "All required workflows on `main` green" (mutation cron) — community/self-hosted v1.2.1 | Closed 2026-05-10 on the equivalent-source argument: scheduled `mutation.yml` cron run [25620978280](https://github.com/apet97/go-clockify/actions/runs/25620978280) (event=`schedule`, headSha `ab2a51e55b0e0116a3235b5254733999dca52e90`, completed/success at 2026-05-10T05:39:41Z) went green across all 6 matrix legs including `Mutation (internal/tools)` — the leg that previously timed out and cancelled every cron since the `2e7b6bd` "May 9 hardening" timeout fix landed. PR #87 (`ab2a51e`) and PR #88 (`2976e24`) modified only `scripts/**` and `docs/**`; `git diff --name-only ab2a51e^..main -- 'internal/**/*.go'` returns no entries. Mutation testing covers `internal/*` packages only, so the green cron on `ab2a51e` is byte-for-byte equivalent-source mutation evidence for both rc.3 (`ce56414`) and current main. This closure applies to the community/self-hosted `v1.2.1` release track only; the literal final-candidate-SHA evidence shape (a scheduled cron landing directly on the final `v1.2.1` SHA) remains a cadence wait that the next regular weekday cron will satisfy. Full evidence record: [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md) § "Mutation cron post-fix evidence — 2026-05-10". |
 | Repository description + issue #28 | Both closed during the 2026-05-09 repo-state cleanup pass landed via PR #77 (`a5d5f75`). |
 
 ### Open gates with exact next-step action
@@ -1232,7 +1233,6 @@ Lane 6 does not close them.
 | Gate | Next-step action |
 |---|---|
 | Group 7 — `make release-check` from clean checkouts on **Linux x64 + macOS arm64** | Re-run `scripts/prepare-rc-evidence.sh v1.2.1-rc.3` from a clean tag checkout on a Linux x64 host (this lane is single-host darwin-arm64); attach the per-host log alongside the existing macOS arm64 log. The macOS arm64 leg already reproduced clean on re-run; only the Linux x64 leg is missing. |
-| Group 7 — "All required workflows on `main` green" (mutation cron) | Wait for the next scheduled `mutation.yml` cron green on the final candidate SHA. The `internal/tools` matrix-leg timeout fix landed on `main` in `2e7b6bd`; the latest scheduled run [25592823559](https://github.com/apet97/go-clockify/actions/runs/25592823559) is still `completed/cancelled` on `4fe957547f9e6aea749a85f87823d17a0ccc2928` (pre-fix). This gate stays **OPEN** until a scheduled `mutation.yml` cron records green on a final candidate SHA — the current rc.3 SHA `ce56414` does not satisfy this gate because no scheduled mutation cron has fired against it yet. |
 | npm publish path on next rc/release | On the next rc/release publish, re-run `scripts/check-launch-external-status.sh --candidate-sha <sha> --expected-npm-version vX.Y.Z[-rc.N] --fail-open`. The validator now recognises prerelease dist-tags (Lane D, PR #87, 2026-05-10), so a passing `--expected-npm-version v1.2.1-rc.3` invocation closes the npm proof against `dist-tags.rc` directly. This is forward-looking on the next publish; it does not block the current rc.3 → final v1.2.1 cut. |
 
 The five paid-hosted / commercial dispositions previously occupying
@@ -1247,7 +1247,11 @@ operator-side request packets remain available there for the future
 paid-hosted launch path. Issue #78 (restore the historical 19-context
 required-status list on `main`) closed on 2026-05-10 with branch
 protection re-applied at 21 contexts; see the "Closed gates with
-evidence anchors" table above.
+evidence anchors" table above. The Group 7 "All required workflows on
+`main` green" (mutation cron) gate closed on 2026-05-10 for the
+community/self-hosted `v1.2.1` track on the equivalent-source
+argument captured in the "Closed gates with evidence anchors" table
+above.
 
 ### Validator quirks vs real blockers
 
@@ -1318,12 +1322,14 @@ on 2026-05-10 against HEAD `3ee4847` (= `main` post-PR #85):
 ### Non-claim
 
 This audit does not declare the repository launch-ready. Final
-`v1.2.1` tag is post-Lane-6 and requires operator action. The two
-remaining active community/self-hosted release blockers (Group 7
-two-host `make release-check` Linux x64 evidence, and the Group 7
-"All required workflows on `main` green" mutation cron closure
-decision) must each close on real evidence before any agent or human
-reports "launch candidate ready" — let alone "launch-ready". The
+`v1.2.1` tag is post-Lane-6 and requires operator action. The single
+remaining active community/self-hosted release blocker (Group 7
+two-host `make release-check` Linux x64 evidence) must close on real
+evidence before any agent or human reports "launch candidate ready" —
+let alone "launch-ready". The Group 7 "All required workflows on
+`main` green" (mutation cron) gate closed on 2026-05-10 for the
+community/self-hosted track on the equivalent-source argument
+recorded in the "Closed gates with evidence anchors" table above. The
 forward-looking npm publish path row is informational on the next
 publish, not a blocker for the current rc.3 → final v1.2.1 cut. The
 five paid-hosted / commercial follow-ups (paid-hosted external

--- a/docs/runbooks/release-candidate-evidence.md
+++ b/docs/runbooks/release-candidate-evidence.md
@@ -532,4 +532,49 @@ Reports `4 open, 0 unknown` against `ce56414`:
 - `mutation.yml`: latest scheduled run 25592823559 still `completed/cancelled` on pushed commit `4fe957547f9e6aea749a85f87823d17a0ccc2928` because that scheduled cron fired before the `internal/tools` matrix-leg timeout fix (`2e7b6bd`) landed. The Group 7 "All required workflows on `main` green" box stays open until the next scheduled `mutation.yml` cron records green on the final candidate SHA.
 - `npm publish path` (rc.3 audit at the time of the Group 7 record): the verifier originally matched `dist-tags.latest` (designed for stable releases) and ignored `dist-tags.rc`, so it reported `[open]` against rc.3 even though the publish path had correctly used `--tag rc`. `npm view @apet97/clockify-mcp-go --json` shows `dist-tags = {"latest":"1.2.0","rc":"1.2.1-rc.3"}` — the expected prerelease shape (`rc` dist-tag bumped, `latest` unchanged because the publish path correctly used `--tag rc` for the prerelease per the rc.2 fix in PR #80). Lane D closed this validator quirk on 2026-05-10: `scripts/check-launch-external-status.sh` now derives the dist-tag from the expected prerelease identifier (rc / beta / alpha / next, mirroring `scripts/publish-npm.sh`) and validates `dist-tags.<derived>`. Re-running the rc.3 invocation above now closes the npm proof against `dist-tags.rc` directly, dropping the npm row from this snapshot's open list and leaving the remaining opens unchanged (local branch cleanup, Group 1 SHA mismatch, mutation cron).
 
-Group 7 boxes that closed on this evidence: the **Release artefacts** box (sigstore + SLSA + SBOMs + container image) and the **`clockify-mcp doctor --strict`** box (release-smoke-doctor-output artifact + local re-verification). Group 7 boxes that remain open: **`make release-check` from clean checkouts on Linux x64 + macOS arm64** (this lane is single-host darwin-arm64 only and the macOS arm64 release-check itself transient-failed on the first invocation), and **All required workflows on `main` green** (mutation.yml's next scheduled cron green on the final candidate SHA is still pending).
+Group 7 boxes that closed on this evidence: the **Release artefacts** box (sigstore + SLSA + SBOMs + container image) and the **`clockify-mcp doctor --strict`** box (release-smoke-doctor-output artifact + local re-verification). The **All required workflows on `main` green** (mutation cron) box closed on 2026-05-10 for the community/self-hosted `v1.2.1` track on the equivalent-source argument captured below — see "Mutation cron post-fix evidence — 2026-05-10". Group 7 box that remains open: **`make release-check` from clean checkouts on Linux x64 + macOS arm64** (this lane is single-host darwin-arm64 only and the macOS arm64 release-check itself transient-failed on the first invocation; the Linux x64 leg is still missing).
+
+## Mutation cron post-fix evidence — 2026-05-10
+
+Scheduled `mutation.yml` cron has now run green on a post-fix `main` SHA, removing the previously-cited "no scheduled cron has fired post-fix" blocker for the Group 7 "All required workflows on `main` green" gate. The literal final-candidate-SHA evidence shape (a scheduled cron landing directly on the SHA `v1.2.1` is cut from) remains a cadence wait — recorded here as partial-but-decisive evidence so the gate's status reflects observed reality.
+
+| Field | Value |
+|---|---|
+| Workflow | `mutation.yml` |
+| Run ID | [25620978280](https://github.com/apet97/go-clockify/actions/runs/25620978280) |
+| Event | `schedule` (NOT `workflow_dispatch`) |
+| Head SHA | `ab2a51e55b0e0116a3235b5254733999dca52e90` |
+| createdAt | 2026-05-10T05:39:41Z |
+| Status / conclusion | `completed` / `success` |
+| Matrix legs (all green) | `Mutation (internal/tools)`, `Mutation (internal/ratelimit)`, `Mutation (internal/enforcement)`, `Mutation (internal/mcp)`, `Mutation (internal/truncate)`, `Mutation (internal/jsonschema)` |
+| `internal/tools` leg (the previously-timing-out leg) | `success` — the `2e7b6bd` "May 9 hardening" timeout fix is verified working under real scheduled-cron load |
+
+### SHA equivalence note (why this evidence covers rc.3 and current main)
+
+The mutation cron tested SHA `ab2a51e`. The relevant downstream SHAs are:
+
+- `ce56414` — `v1.2.1-rc.3` peeled commit (one commit before `ab2a51e`).
+- `2976e24` — current `main` after PR #88 (one commit after `ab2a51e`).
+
+`git diff --name-only ab2a51e^..2976e24 -- 'internal/**/*.go'` returns no entries: PR #87 (which becomes `ab2a51e`) modified only `scripts/check-launch-external-status.sh` and `scripts/test-check-launch-external-status.sh`, and PR #88 (which becomes `2976e24`) modified only `docs/**` files. Mutation testing covers `internal/*` packages only; neither PR changed any code under that scope.
+
+Therefore the mutation cron green on `ab2a51e` is byte-for-byte equivalent-source mutation evidence for both `ce56414` (rc.3 codebase) and `2976e24` (current main codebase). The `internal/tools` timeout fix is verified working on the full mutation matrix shape in production scheduled-cron conditions.
+
+### What this record does NOT do
+
+- Does **NOT** by itself close the Group 7 "All required workflows on `main` green" gate's literal evidence shape (which binds to a scheduled cron landing directly on the final candidate SHA — i.e., the SHA `v1.2.1` is cut from). That cadence wait is now hours, not days — the next regular weekday scheduled cron will satisfy it.
+- Does **NOT** declare the repository launch-ready.
+- Does **NOT** retag `v1.2.1-rc.3` or cut `v1.2.1`.
+- Does **NOT** modify `mutation.yml`'s cadence or add a `workflow_dispatch` shortcut.
+- Does **NOT** tick the "All required workflows on `main` green" checkbox in `docs/launch-candidate-checklist.md`. The literal SHA-binding wording leaves that to the operator's review.
+
+### Operator decision
+
+On 2026-05-10 the maintainer accepted the equivalent-source closure for the **community/self-hosted `v1.2.1`** release track. The decision is recorded in [`docs/launch-readiness-review-may-8.md`](../launch-readiness-review-may-8.md) § "Closed gates with evidence anchors", row "Group 7 — 'All required workflows on `main` green' (mutation cron) — community/self-hosted v1.2.1", citing run [25620978280](https://github.com/apet97/go-clockify/actions/runs/25620978280) plus the `git diff --name-only ab2a51e^..main -- 'internal/**/*.go'` empty-diff proof above. `mutation.yml` was **not** modified — no cadence change, no `workflow_dispatch` shortcut, no test removed.
+
+Closure scope:
+
+- **Closed for community/self-hosted `v1.2.1`** on the equivalent-source argument above. This is the release track that does not claim official Clockify status, does not promise paid-hosted SLAs, and ships under the existing AGPLv3 community licence.
+- **Still pending in literal SHA-binding form** for any future paid-hosted / commercial track that requires a scheduled cron to land directly on the SHA `v1.2.1` (or the next paid-hosted candidate) is cut from. That cadence wait is hours, not days; the next regular weekday scheduled cron will satisfy it.
+
+This record does not declare the repository launch-ready, does not retag `v1.2.1-rc.3` or cut `v1.2.1`, does not modify branch protection, and does not tick checkboxes outside the `mutation.yml`-bound row in the launch-readiness ledger.


### PR DESCRIPTION
> ✅ **Ready.** Records mutation cron post-fix evidence captured 2026-05-10 from scheduled run [25620978280](https://github.com/apet97/go-clockify/actions/runs/25620978280) **and closes the gate on the equivalent-source argument for the community/self-hosted `v1.2.1` track**. Does **not** declare launch-ready, does **not** retag any rc, does **not** modify branch protection, does **not** reopen issue #78, does **not** modify `mutation.yml`, does **not** re-promote any of the deferred paid-hosted/commercial gates.

## Summary

The `internal/tools` matrix-leg timeout fix (`2e7b6bd` "May 9 hardening") that previously cancelled every scheduled `mutation.yml` cron is **verified working under real scheduled-cron load**. Run 25620978280 (event=schedule, headSha `ab2a51e`, conclusion success) at 2026-05-10T05:39:41Z went green across all 6 matrix legs including `Mutation (internal/tools)`.

PR #87 (`ab2a51e`) and PR #88 (`2976e24`) added no `internal/*` Go source changes. PR #90 (`da7f931`) is docs-only. So the green cron on `ab2a51e` is byte-for-byte equivalent-source mutation evidence for both rc.3 (`ce56414`) and current main (`da7f931`).

## Closure decision

On 2026-05-10 the maintainer accepted the equivalent-source closure for the **community/self-hosted `v1.2.1`** release track:

- The Group 7 "All required workflows on `main` green" (mutation cron) gate moves to `docs/launch-readiness-review-may-8.md` § "Closed gates with evidence anchors", row "Group 7 — 'All required workflows on `main` green' (mutation cron) — community/self-hosted v1.2.1".
- The literal final-candidate-SHA evidence shape (a scheduled cron landing directly on the SHA `v1.2.1` is cut from) remains a cadence wait that the next regular weekday cron will satisfy. That is recorded explicitly in the runbook section as the conservative SHA-literal reading; community/self-hosted closure does not depend on it.

Active community/self-hosted v1.2.1 release blockers after this PR lands: **only** Group 7 Linux x64 `make release-check` evidence.

## What changed

- `docs/launch-readiness-review-may-8.md` — mutation cron row removed from "Open gates with exact next-step action"; new "Closed gates with evidence anchors" row added with run ID, matrix-leg breakdown, equivalent-source argument, and explicit community/self-hosted scope. Non-claim paragraph updated so the "two remaining active blockers" wording becomes "single remaining active blocker" (Linux x64).
- `docs/runbooks/release-candidate-evidence.md` — "Mutation cron post-fix evidence — 2026-05-10" subsection updated so "Operator decision point" becomes "Operator decision" recording the actual closure choice; the rc.3 closure-summary line above also reflects the closure rather than "still pending".

## Rebase

Rebased onto post-#90 main on 2026-05-10. The single conflict (the `Open gates` table reshape) was resolved by removing the mutation cron row from `Open gates` and adding the equivalent-source-anchored closure row to `Closed gates with evidence anchors`. The five paid-hosted/commercial deferred-section rows were preserved exactly as PR #90 left them and were not re-promoted to active blockers.

## What this PR does NOT do

- ❌ Does **NOT** tick any checkbox in `docs/launch-candidate-checklist.md`.
- ❌ Does **NOT** declare the repository launch-ready.
- ❌ Does **NOT** retag any rc.
- ❌ Does **NOT** cut `v1.2.1`.
- ❌ Does **NOT** modify branch protection on `main`.
- ❌ Does **NOT** reopen issue #78.
- ❌ Does **NOT** modify `mutation.yml` (no cadence change, no `workflow_dispatch` shortcut, no test removed).
- ❌ Does **NOT** re-promote any of the five deferred paid-hosted/commercial gates to active community/self-hosted v1.2.1 blockers.

## Verification

- [x] `make doc-parity` — doc-parity / launch-review-ledger / launch-checklist-parity / launch-evidence-gate all OK
- [x] `make launch-checklist-parity` — OK
- [x] `make script-tests` — all 18 suites green (publish-npm, claude-campaign, evidence-gate, check-launch-external-status, check-launch-review-ledger 39/39, etc.)
- [x] `git diff --check` — clean
- [x] Equivalent-source proof: `git diff --name-only ab2a51e^..main -- 'internal/**/*.go'` returns empty (after PR #90 merge `da7f931`)

## Related

- Mutation cron run: https://github.com/apet97/go-clockify/actions/runs/25620978280
- PR #90: docs(launch): scope-correct paid-hosted gates to deferred follow-ups (`da7f931`)
- Equivalent-source proof command: `git diff --name-only ab2a51e^..da7f931 -- 'internal/**/*.go'` (empty)