### PR TITLE
docs(launch): record Linux x64 release-check evidence for v1.2.1-rc.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ desktop.ini
 .review/
 # Local duplicate clone sometimes created during agent handoffs.
 /go-clockify/
+# Lane B Linux x64 release-check Docker evidence (Lane B 2026-05-10).
+# Logs land here on the host but are referenced from
+# docs/runbooks/release-candidate-evidence.md, not committed.
+.linux-x64-evidence/
 # Per-workstation Claude Code context. Contributors may keep their
 # own CLAUDE.md at the repo root; it carries machine-specific
 # preferences and is not part of the shipped project. AGENTS.md, by

--- a/docs/launch-readiness-review-may-8.md
+++ b/docs/launch-readiness-review-may-8.md
@@ -1226,13 +1226,13 @@ Lane 6 does not close them.
 | Branch protection on `main` carries the three D9 launch checks | Re-applied 2026-05-09 with `Doctor strict smoke`, `Doctor Postgres backend`, and `Shared-service Postgres E2E` required (strict up-to-date, linear history, conversation resolution, no force push, no deletion). |
 | Issue #78 — restore the historical 19-context required-status list on `main` | Closed 2026-05-10 after the 21-context branch-protection restoration landed (additive PUT against `repos/apet97/go-clockify/branches/main/protection`). The classic `required_status_checks.contexts` array now carries the historical 18 plus the three D9 launch checks (`Doctor strict smoke`, `Doctor Postgres backend`, `Shared-service Postgres E2E`); `scripts/audit-branch-protection.sh` confirms the live state matches the documented snapshot in [`branch-protection.md`](branch-protection.md). |
 | Group 7 — "All required workflows on `main` green" (mutation cron) — community/self-hosted v1.2.1 | Closed 2026-05-10 on the equivalent-source argument: scheduled `mutation.yml` cron run [25620978280](https://github.com/apet97/go-clockify/actions/runs/25620978280) (event=`schedule`, headSha `ab2a51e55b0e0116a3235b5254733999dca52e90`, completed/success at 2026-05-10T05:39:41Z) went green across all 6 matrix legs including `Mutation (internal/tools)` — the leg that previously timed out and cancelled every cron since the `2e7b6bd` "May 9 hardening" timeout fix landed. PR #87 (`ab2a51e`) and PR #88 (`2976e24`) modified only `scripts/**` and `docs/**`; `git diff --name-only ab2a51e^..main -- 'internal/**/*.go'` returns no entries. Mutation testing covers `internal/*` packages only, so the green cron on `ab2a51e` is byte-for-byte equivalent-source mutation evidence for both rc.3 (`ce56414`) and current main. This closure applies to the community/self-hosted `v1.2.1` release track only; the literal final-candidate-SHA evidence shape (a scheduled cron landing directly on the final `v1.2.1` SHA) remains a cadence wait that the next regular weekday cron will satisfy. Full evidence record: [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md) § "Mutation cron post-fix evidence — 2026-05-10". |
+| Group 7 — `make release-check` from clean checkouts on **Linux x64 + macOS arm64** | Closed 2026-05-10 once both host legs landed for `v1.2.1-rc.3` (peeled commit `ce56414ae012c4a49d21ae0a319b178619c5966a`). The macOS arm64 leg comes from the rc.3 `opus/group7-release-rc3-20260510` worktree (re-run after the transient TMPDIR concurrency failure cleared on its second invocation, evidence in the rc.3 record above). The Linux x64 leg comes from a Lane B Docker `linux/amd64` `golang:1.25-bookworm` clean-clone run between `2026-05-10T17:05:40Z` and `2026-05-10T17:21:48Z`: container kernel `Linux 04187e400898 6.10.14-linuxkit #1 SMP Sat May 17 08:28:57 UTC 2025 x86_64`, toolchain `go version go1.25.10 linux/amd64`, `make release-check` exit `0` with final line `release-check: OK — local pre-ship gate passed`. Full Linux x64 evidence shape (host info, command transcript, per-phase summary, log artefact paths) is in [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md) § "Linux x64 release-check evidence — v1.2.1-rc.3". |
 | Repository description + issue #28 | Both closed during the 2026-05-09 repo-state cleanup pass landed via PR #77 (`a5d5f75`). |
 
 ### Open gates with exact next-step action
 
 | Gate | Next-step action |
 |---|---|
-| Group 7 — `make release-check` from clean checkouts on **Linux x64 + macOS arm64** | Re-run `scripts/prepare-rc-evidence.sh v1.2.1-rc.3` from a clean tag checkout on a Linux x64 host (this lane is single-host darwin-arm64); attach the per-host log alongside the existing macOS arm64 log. The macOS arm64 leg already reproduced clean on re-run; only the Linux x64 leg is missing. |
 | npm publish path on next rc/release | On the next rc/release publish, re-run `scripts/check-launch-external-status.sh --candidate-sha <sha> --expected-npm-version vX.Y.Z[-rc.N] --fail-open`. The validator now recognises prerelease dist-tags (Lane D, PR #87, 2026-05-10), so a passing `--expected-npm-version v1.2.1-rc.3` invocation closes the npm proof against `dist-tags.rc` directly. This is forward-looking on the next publish; it does not block the current rc.3 → final v1.2.1 cut. |
 
 The five paid-hosted / commercial dispositions previously occupying
@@ -1251,7 +1251,14 @@ evidence anchors" table above. The Group 7 "All required workflows on
 `main` green" (mutation cron) gate closed on 2026-05-10 for the
 community/self-hosted `v1.2.1` track on the equivalent-source
 argument captured in the "Closed gates with evidence anchors" table
-above.
+above. The Group 7 two-host `make release-check` gate also closed on
+2026-05-10 once the Linux x64 leg landed alongside the existing
+macOS arm64 leg — see the "Closed gates with evidence anchors" row
+and the "Linux x64 release-check evidence — v1.2.1-rc.3" subsection
+in the runbook. With those three closures the `Open gates` table
+carries only the forward-looking npm publish-path row, which is
+informational on the next publish and does not block the current
+rc.3 → final v1.2.1 cut.
 
 ### Validator quirks vs real blockers
 
@@ -1322,25 +1329,27 @@ on 2026-05-10 against HEAD `3ee4847` (= `main` post-PR #85):
 ### Non-claim
 
 This audit does not declare the repository launch-ready. Final
-`v1.2.1` tag is post-Lane-6 and requires operator action. The single
-remaining active community/self-hosted release blocker (Group 7
-two-host `make release-check` Linux x64 evidence) must close on real
-evidence before any agent or human reports "launch candidate ready" —
-let alone "launch-ready". The Group 7 "All required workflows on
-`main` green" (mutation cron) gate closed on 2026-05-10 for the
-community/self-hosted track on the equivalent-source argument
-recorded in the "Closed gates with evidence anchors" table above. The
-forward-looking npm publish path row is informational on the next
-publish, not a blocker for the current rc.3 → final v1.2.1 cut. The
-five paid-hosted / commercial follow-ups (paid-hosted external
-security review, DPA / privacy / trademark approval, paid-commercial
-RLS, cross-replica hosted HTTP quotas, plus the trademark-coupled
-`clockify://` URI / gRPC service-name branding review) are now
-explicitly **deferred** under "## Deferred paid-hosted/commercial
-follow-ups — not required for community/self-hosted v1.2.1" and do
-**not** block the community/self-hosted `v1.2.1` cut so long as the
-release notes and public docs keep the project framed as
-community/self-hosted and do not claim official Clockify status.
+`v1.2.1` tag is post-Lane-6 and requires operator action. As of
+2026-05-10 there are **zero** active community/self-hosted release
+blockers in this ledger: the Group 7 two-host `make release-check`
+gate closed once the Linux x64 leg landed (see the rc.3 evidence
+record and the new "Linux x64 release-check evidence — v1.2.1-rc.3"
+subsection in the runbook), and the Group 7 "All required workflows
+on `main` green" (mutation cron) gate closed on the equivalent-source
+argument also captured above. The forward-looking npm publish path
+row is informational on the next publish, not a blocker for the
+current rc.3 → final v1.2.1 cut. The five paid-hosted / commercial
+follow-ups (paid-hosted external security review, DPA / privacy /
+trademark approval, paid-commercial RLS, cross-replica hosted HTTP
+quotas, plus the trademark-coupled `clockify://` URI / gRPC
+service-name branding review) are explicitly **deferred** under
+"## Deferred paid-hosted/commercial follow-ups — not required for
+community/self-hosted v1.2.1" and do **not** block the
+community/self-hosted `v1.2.1` cut so long as the release notes and
+public docs keep the project framed as community/self-hosted and do
+not claim official Clockify status. Cutting `v1.2.1` is still a
+maintainer action; this audit only records that the active
+community/self-hosted blocker list is empty.
 
 ## Verification used for this pass
 

--- a/docs/runbooks/release-candidate-evidence.md
+++ b/docs/runbooks/release-candidate-evidence.md
@@ -532,7 +532,74 @@ Reports `4 open, 0 unknown` against `ce56414`:
 - `mutation.yml`: latest scheduled run 25592823559 still `completed/cancelled` on pushed commit `4fe957547f9e6aea749a85f87823d17a0ccc2928` because that scheduled cron fired before the `internal/tools` matrix-leg timeout fix (`2e7b6bd`) landed. The Group 7 "All required workflows on `main` green" box stays open until the next scheduled `mutation.yml` cron records green on the final candidate SHA.
 - `npm publish path` (rc.3 audit at the time of the Group 7 record): the verifier originally matched `dist-tags.latest` (designed for stable releases) and ignored `dist-tags.rc`, so it reported `[open]` against rc.3 even though the publish path had correctly used `--tag rc`. `npm view @apet97/clockify-mcp-go --json` shows `dist-tags = {"latest":"1.2.0","rc":"1.2.1-rc.3"}` — the expected prerelease shape (`rc` dist-tag bumped, `latest` unchanged because the publish path correctly used `--tag rc` for the prerelease per the rc.2 fix in PR #80). Lane D closed this validator quirk on 2026-05-10: `scripts/check-launch-external-status.sh` now derives the dist-tag from the expected prerelease identifier (rc / beta / alpha / next, mirroring `scripts/publish-npm.sh`) and validates `dist-tags.<derived>`. Re-running the rc.3 invocation above now closes the npm proof against `dist-tags.rc` directly, dropping the npm row from this snapshot's open list and leaving the remaining opens unchanged (local branch cleanup, Group 1 SHA mismatch, mutation cron).
 
-Group 7 boxes that closed on this evidence: the **Release artefacts** box (sigstore + SLSA + SBOMs + container image) and the **`clockify-mcp doctor --strict`** box (release-smoke-doctor-output artifact + local re-verification). The **All required workflows on `main` green** (mutation cron) box closed on 2026-05-10 for the community/self-hosted `v1.2.1` track on the equivalent-source argument captured below — see "Mutation cron post-fix evidence — 2026-05-10". Group 7 box that remains open: **`make release-check` from clean checkouts on Linux x64 + macOS arm64** (this lane is single-host darwin-arm64 only and the macOS arm64 release-check itself transient-failed on the first invocation; the Linux x64 leg is still missing).
+Group 7 boxes that closed on this evidence: the **Release artefacts** box (sigstore + SLSA + SBOMs + container image) and the **`clockify-mcp doctor --strict`** box (release-smoke-doctor-output artifact + local re-verification). The **All required workflows on `main` green** (mutation cron) box closed on 2026-05-10 for the community/self-hosted `v1.2.1` track on the equivalent-source argument captured below — see "Mutation cron post-fix evidence — 2026-05-10". The **`make release-check` from clean checkouts on Linux x64 + macOS arm64** box closed on 2026-05-10 once both legs landed: the macOS arm64 leg from the Lane 3 worktree (re-run after the transient TMPDIR concurrency failure cleared on its second invocation) and the Linux x64 leg from the Lane B Docker `linux/amd64` `golang:1.25-bookworm` clean-clone evidence captured 2026-05-10T17:05:40Z–17:21:48Z — see "Linux x64 release-check evidence — v1.2.1-rc.3" below.
+
+### Linux x64 release-check evidence — v1.2.1-rc.3
+
+Captured 2026-05-10 by Lane B (Docker `linux/amd64` on Apple Silicon coordinator host; QEMU-emulated x86_64 build, ~16 minutes wall time). The macOS arm64 leg already lives in the rc.3 evidence section above; this subsection is the missing Linux x64 leg.
+
+| Field | Value |
+|---|---|
+| Host / runner | Docker container `golang:1.25-bookworm` on Docker Desktop, `--platform linux/amd64` (QEMU emulation under macOS arm64 coordinator) |
+| Container kernel | `Linux 04187e400898 6.10.14-linuxkit #1 SMP Sat May 17 08:28:57 UTC 2025 x86_64 GNU/Linux` |
+| Image | `golang:1.25-bookworm` (digest `sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547`) |
+| Toolchain | `go version go1.25.10 linux/amd64` (matches the repo Go pin) |
+| Candidate tag | `v1.2.1-rc.3` |
+| Peeled commit | `ce56414ae012c4a49d21ae0a319b178619c5966a` |
+| Worktree state | clean (`git status --short` empty after `git checkout v1.2.1-rc.3`) |
+| Start (UTC) | `2026-05-10T17:05:40Z` |
+| End (UTC) | `2026-05-10T17:21:48Z` |
+| `make release-check` exit | `0` |
+| Final line | `release-check: OK — local pre-ship gate passed` |
+| `scripts/prepare-rc-evidence.sh v1.2.1-rc.3` | exit `1` — fails closed with `ERROR: govulncheck is required for candidate evidence`. The bundled `tools/govulncheck` module was intentionally not pre-installed in the Lane B container; this is **outside** the Group 7 `make release-check` evidence shape and is captured here as informational only. |
+
+Command transcript (run from a clean clone inside the container):
+
+```sh
+docker run --rm --platform linux/amd64 \
+  -v "${EVIDENCE_HOST}:/evidence" \
+  -w /work \
+  golang:1.25-bookworm \
+  bash -c '
+    set -euo pipefail
+    export PATH="/usr/local/go/bin:${PATH}"
+    apt-get update -qq && apt-get install -y -qq make jq curl git ca-certificates ripgrep
+    git config --global --add safe.directory /work/repo
+    git clone --quiet https://github.com/apet97/go-clockify.git /work/repo
+    cd /work/repo
+    git fetch --quiet --tags origin
+    git checkout --quiet v1.2.1-rc.3
+    uname -a
+    go version
+    git rev-parse HEAD
+    git rev-parse v1.2.1-rc.3^{commit}
+    make release-check 2>&1 | tee /evidence/release-check.linux-x64.log
+  '
+```
+
+`make release-check` walked the documented lane on Linux x64:
+
+- formatting/vet/lint (golangci-lint not installed in the minimal container — release-check noted "golangci-lint not installed, skipping (CI enforces)" and continued; CI's `Lint` job remains the authoritative lint gate)
+- tests + coverage floors (cover-check passed against the documented per-package floors)
+- config + doc parity (`check-config-parity`, `check-doc-parity`, `check-launch-review-ledger`, `check-launch-checklist-parity`, `check-launch-evidence-gate`, `check-config-doc-parity`, `check-grpc-release-parity` all OK)
+- hygiene + build-tag wiring (`check-repo-hygiene` plus 18 script-tests suites green: `filter-bench-output`, `check-bench-baseline 11/11`, `check-coverage 10/10`, `check-doc-parity 70/70`, `check-repo-hygiene 9/9`, `check-governance-parity 12/12`, `check-release-assets 10/10`, `check-launch-checklist-parity 14/14`, `check-launch-review-ledger 39/39`, `check-launch-external-status 24 run, 0 failed`, `audit-branch-protection 2 run, 0 failed`, `check-public-content-audit 6 run, 0 failed`, `check-go-version-parity 9/9`, `check-live-tool-coverage 6 run, 0 failed`, `collect-license-evidence 3/3`, `prepare-rc-evidence 4 run, 0 failed`, `publish-npm 7 run, 0 failed`, `claude-campaign 4 run, 0 failed`)
+- HTTP + stdio smoke (`smoke-http.sh` and `smoke-stdio.sh` both OK; `tools/list returned 40 tools`)
+- strict doctor smoke (`doctor --strict positive and negative smokes passed`)
+- full E2E including gRPC under `-tags=grpc` (`go test -tags=grpc -race -count=1 -timeout 180s ./tests/...` reported `ok github.com/apet97/go-clockify/tests 6.550s` and `ok github.com/apet97/go-clockify/tests/harness 1.272s`)
+- deploy render — auto-skipped per the documented Makefile contract (`[release-check] kubectl/kubeconform/helm missing — skipping k8s render (CI runs the full check).`); CI's k8s render is the authoritative check
+
+Local log artefacts (gitignored, not committed; preserved on the coordinator host for review):
+
+- `${REPO}/.linux-x64-evidence/release-check.linux-x64.log` — full `make release-check` transcript (601 lines, exit `0`)
+- `${REPO}/.linux-x64-evidence/host.txt` — `uname -a`, `go version`, ISO 8601 start, candidate-tag SHA, peeled-commit SHA
+- `${REPO}/.linux-x64-evidence/run.out` — combined runner stdout/stderr from the wrapper
+- `${REPO}/.linux-x64-evidence/run.sh` — exact wrapper command for reproducibility
+- `${REPO}/.linux-x64-evidence/release-check.linux-x64.log.attempt1` — first attempt failure record (`scripts/test-check-live-tool-coverage.sh` failed with `[fail] rg is required for live tool coverage checks` because the minimal Debian container lacked `ripgrep`; resolved in attempt 2 by adding `ripgrep` to the apt-install list)
+- `${REPO}/.linux-x64-evidence/release-check.linux-x64.log.attempt2` — second attempt failure record (`cover-check Error 1` cascading from a transient host-disk-pressure event that put the Docker Desktop VM into read-only mode mid-run; resolved by freeing host disk space and restarting Docker Desktop)
+
+This Linux x64 evidence pairs with the rc.3 macOS arm64 `make release-check` log already captured in the section above to satisfy the Group 7 two-host evidence shape. With both legs present, the Group 7 "make release-check from clean checkouts on Linux x64 + macOS arm64" box is closed for `v1.2.1-rc.3`.
+
+This record does **not** declare the repository launch-ready, does **not** retag `v1.2.1-rc.3`, does **not** cut `v1.2.1`, does **not** modify branch protection, and does **not** re-promote any of the deferred paid-hosted/commercial follow-ups. The `prepare-rc-evidence.sh` Linux x64 invocation is informational only; closure of the Group 7 row depends on `make release-check`, not on `prepare-rc-evidence.sh`.
 
 ## Mutation cron post-fix evidence — 2026-05-10
 


### PR DESCRIPTION
> 🚧 **Draft.** Records the missing Linux x64 leg of the Group 7 two-host `make release-check` evidence for `v1.2.1-rc.3` and moves the row from "Open gates" to "Closed gates with evidence anchors". **If accepted, this closes the final active community/self-hosted release blocker.** Does **not** cut `v1.2.1`, does **not** retag rc.3, does **not** modify branch protection, does **not** reopen issue #78, does **not** declare paid-hosted/commercial readiness, does **not** claim official Clockify status.

## Summary

The Group 7 row `make release-check from clean checkouts on Linux x64 + macOS arm64` had been blocked on the missing Linux x64 leg since rc.3 was cut. This PR captures that leg via a clean Docker `linux/amd64` `golang:1.25-bookworm` clone-and-build, and records the evidence in the canonical runbook + ledger.

| Field | Value |
|---|---|
| Host / runner | Docker `--platform linux/amd64` on Docker Desktop (QEMU-emulated x86_64 under macOS arm64 coordinator) |
| Container kernel | `Linux 04187e400898 6.10.14-linuxkit #1 SMP Sat May 17 08:28:57 UTC 2025 x86_64 GNU/Linux` |
| Image | `golang:1.25-bookworm` (digest `sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547`) |
| Toolchain | `go version go1.25.10 linux/amd64` (matches repo Go pin) |
| Candidate tag | `v1.2.1-rc.3` |
| Peeled commit | `ce56414ae012c4a49d21ae0a319b178619c5966a` |
| Worktree state | clean (`git status --short` empty after checkout) |
| Start (UTC) | `2026-05-10T17:05:40Z` |
| End (UTC) | `2026-05-10T17:21:48Z` |
| `make release-check` exit | `0` |
| Final line | `release-check: OK — local pre-ship gate passed` |

Per-phase walk-through: formatting/vet/lint, tests + coverage floors, config + doc parity, hygiene + 18 script-tests suites all green (incl. `check-live-tool-coverage 6 run, 0 failed`), HTTP + stdio smoke (`tools/list returned 40 tools`), strict doctor smoke (positive + negative), full E2E `go test -tags=grpc -race -count=1 -timeout 180s ./tests/...` green, deploy render auto-skip per documented Makefile contract.

Local log artefact: `${REPO}/.linux-x64-evidence/release-check.linux-x64.log` (gitignored, 601 lines, exit `0`). Two earlier Lane B attempts are preserved as `.attempt1` (failed because the minimal Debian container lacked `ripgrep` for `scripts/test-check-live-tool-coverage.sh`) and `.attempt2` (failed because the macOS host filesystem briefly hit 100% capacity which put the Docker Desktop VM into read-only mode mid-`cover-check`; resolved by freeing host disk and restarting Docker Desktop).

`scripts/prepare-rc-evidence.sh v1.2.1-rc.3` exited `1` under the minimal Lane B container with `ERROR: govulncheck is required for candidate evidence`. That's recorded in the runbook as informational only — the Group 7 two-host gate closes on `make release-check`, not on `prepare-rc-evidence.sh`. Capturing the full prepare-rc-evidence shape on Linux x64 remains an optional follow-up.

## What changed

- `docs/runbooks/release-candidate-evidence.md`
  - New "Linux x64 release-check evidence — v1.2.1-rc.3" subsection: host/image/toolchain table, exact `docker run` invocation, per-phase summary, log artefact paths, explicit non-claim block.
  - rc.3 record's closure-summary line records the two-host `make release-check` closure.
- `docs/launch-readiness-review-may-8.md`
  - Linux x64 row moved from "Open gates with exact next-step action" → "Closed gates with evidence anchors".
  - Non-claim paragraph rewritten to record the `zero` active community/self-hosted release blocker count and the explicit caveat that cutting `v1.2.1` is still a maintainer action.
  - Cross-reference summary paragraph updated to mention the new closure.
- `.gitignore`
  - Add `.linux-x64-evidence/` so the local Lane B Docker output directory does not surface in `git status`.

## Active community/self-hosted v1.2.1 blocker list after this PR lands

**Zero.** With the Group 7 two-host `make release-check` gate closed by this PR, all three Group 7 active gates are closed (release artefacts via PR #85, mutation cron via PR #89, two-host `make release-check` via this PR). The five paid-hosted/commercial follow-ups stay deferred per PR #90. Issue #78 stays closed. The `Open gates` table now carries only the forward-looking npm publish-path row (informational on the next publish; not a v1.2.1 cut blocker).

Cutting `v1.2.1` is still an explicit maintainer action and is **not** performed by this PR.

## What this PR does NOT do

- ❌ Does **NOT** cut `v1.2.1`.
- ❌ Does **NOT** retag `v1.2.1-rc.3`.
- ❌ Does **NOT** declare paid-hosted/commercial readiness.
- ❌ Does **NOT** claim official Clockify status.
- ❌ Does **NOT** modify branch protection on `main`.
- ❌ Does **NOT** reopen issue #78.
- ❌ Does **NOT** remove or modify any of the PR #88 packet docs.
- ❌ Does **NOT** re-promote any of the five deferred paid-hosted/commercial follow-ups.
- ❌ Does **NOT** modify `mutation.yml`, `release.yml`, or any other workflow.

## Verifier results (all green)

- `make doc-parity` → doc-parity / launch-review-ledger / launch-checklist-parity / launch-evidence-gate all OK
- `make launch-checklist-parity` → OK
- `make script-tests` → all 18 suites green (publish-npm 7/0-failed, claude-campaign 4/0-failed, check-launch-external-status 24/0-failed, check-launch-review-ledger 39/39, check-doc-parity 70/70, check-live-tool-coverage 6/0-failed, etc.)
- `git diff --check` → exit 0
- Linux x64 `make release-check` itself → exit 0 with `release-check: OK — local pre-ship gate passed` final line

## Test plan

- [x] `make doc-parity` clean
- [x] `make launch-checklist-parity` clean
- [x] `make script-tests` clean (all 18 suites)
- [x] `git diff --check` clean
- [x] Lane B Docker `make release-check` exit 0 confirmed against rc.3 peeled commit `ce56414`
- [ ] Reviewer spot-check: closure verdict matches the Group 7 evidence shape and does not lean on macOS arm64 as a dual-host claim
- [ ] Reviewer spot-check: ledger non-claim still says cutting `v1.2.1` is a maintainer action and is not performed here

## Related

- PR #90 (paid-hosted scope correction, merged `da7f931`)
- PR #89 (mutation cron equivalent-source closure, merged `637157d`)
- v1.2.1-rc.3 release: https://github.com/apet97/go-clockify/releases/tag/v1.2.1-rc.3