### PR TITLE
fix(release): pin GoReleaser to explicit GitHub ref tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,18 @@ name: Release
 on:
   push:
     tags: ["v*.*.*"]
+  # Manual retry path. The on-tag-push trigger above cannot be re-fired
+  # without forbidden tag movement once a tag exists, so workflow_dispatch
+  # is the supported way to re-run this workflow against an already-cut
+  # tag (e.g. when the first run failed mid-publish). The dispatch path
+  # checks out the requested tag, validates its existence, and pins
+  # GoReleaser to it. Tag deletion / retag / force-push are NOT used.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v* tag to release (e.g. v1.2.1)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -21,7 +33,81 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # On tag push: github.ref is refs/tags/<tag>, so checking out
+          # the default ref is the tag itself.
+          # On workflow_dispatch: check out the requested tag explicitly
+          # so the build context matches the release artefact target.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
+      - name: Resolve and validate release tag
+        id: resolve-release-tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          # Pinning rationale:
+          #   v1.2.1 and v1.2.1-rc.3 (and any future final/rc pair) can
+          #   point to the same commit because the final tag is cut from
+          #   the rc.3 peeled commit. GoReleaser's auto tag-detection
+          #   (git describe / closest tag) is ambiguous in that case and
+          #   has been observed to pick the rc tag while the release is
+          #   intended for the final tag — see run 25635476567 where
+          #   `tag=v1.2.1-rc.3` was logged during a v1.2.1 push, every
+          #   asset upload hit 422 already_exists against the existing
+          #   rc.3 release, and the v1.2.1 GitHub Release was never
+          #   created. Pinning GORELEASER_CURRENT_TAG and the npm /
+          #   downstream-dispatch RELEASE_VERSION env vars to this
+          #   resolved tag closes that ambiguity. Existing tags must NOT
+          #   be deleted, moved, or recreated to fix this; the workflow
+          #   itself is the right place to remove the ambiguity.
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            release_tag="${INPUT_TAG}"
+          else
+            release_tag="${REF_NAME}"
+          fi
+          echo "Resolved release tag: ${release_tag}"
+          # Shape guard. GoReleaser config and downstream verifiers
+          # expect a v-prefixed semver tag (with optional -rc.N or
+          # similar prerelease suffix).
+          case "${release_tag}" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            v[0-9]*.[0-9]*.[0-9]*-*) ;;
+            *)
+              echo "::error::release tag ${release_tag} does not match expected vMAJOR.MINOR.PATCH[-suffix] shape"
+              exit 1
+              ;;
+          esac
+          # Make sure the local tag database has the requested tag. On
+          # workflow_dispatch the checkout above already checked out the
+          # ref by name, but actions/checkout@v6 with fetch-depth: 0 will
+          # not always re-fetch tag annotations after the dispatch ref is
+          # resolved; re-fetch explicitly so the rev-parse below is
+          # authoritative.
+          git fetch --force --tags origin
+          if ! git rev-parse "${release_tag}" >/dev/null 2>&1; then
+            echo "::error::release tag ${release_tag} does not exist on origin"
+            exit 1
+          fi
+          release_commit="$(git rev-parse "${release_tag}^{commit}")"
+          echo "Resolved peeled commit: ${release_commit}"
+          # Pinned-commit guard for the v1.2.1 community/self-hosted cut.
+          # rc.3 peeled to ce56414ae012c4a49d21ae0a319b178619c5966a, and
+          # the launch-readiness ledger records v1.2.1 as cut from that
+          # exact commit. A mismatch here would mean either the tag was
+          # rewritten (forbidden) or the workflow is targeting a
+          # different revision than the published evidence — fail closed.
+          if [ "${release_tag}" = "v1.2.1" ] && [ "${release_commit}" != "ce56414ae012c4a49d21ae0a319b178619c5966a" ]; then
+            echo "::error::v1.2.1 must peel to ce56414ae012c4a49d21ae0a319b178619c5966a (per docs/launch-readiness-review-may-8.md), got ${release_commit}"
+            exit 1
+          fi
+          echo "Tags pointing at HEAD (audit context):"
+          git tag --points-at HEAD || true
+          {
+            echo "release_tag=${release_tag}"
+            echo "release_commit=${release_commit}"
+          } >>"${GITHUB_OUTPUT}"
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.10"
@@ -43,6 +129,10 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Explicit pin — see "Resolve and validate release tag" step
+          # rationale. Stops GoReleaser from picking the rc.3 sibling
+          # tag when both tags peel to the same commit.
+          GORELEASER_CURRENT_TAG: ${{ steps.resolve-release-tag.outputs.release_tag }}
       - name: Verify release asset count
         # Structural gate against the v0.7.0 class of bug (goreleaser
         # filter silently drops a whole artifact category). Fails the
@@ -118,7 +208,11 @@ jobs:
       - name: Publish npm packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          RELEASE_VERSION: ${{ github.ref_name }}
+          # Pinned to the resolved release tag (see resolve-release-tag
+          # step) instead of github.ref_name so workflow_dispatch retries
+          # land on the right tag, and so a final-vs-rc tag pair pointing
+          # at the same commit cannot make npm publish a misnamed tarball.
+          RELEASE_VERSION: ${{ steps.resolve-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
           if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
@@ -131,7 +225,8 @@ jobs:
       - name: Trigger reproducibility verification
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ github.ref_name }}
+          # Pinned — see resolve-release-tag rationale.
+          RELEASE_VERSION: ${{ steps.resolve-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
           # GoReleaser creates the GH release via GITHUB_TOKEN, which
@@ -148,7 +243,8 @@ jobs:
       - name: Trigger release smoke verification
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ github.ref_name }}
+          # Pinned — see resolve-release-tag rationale.
+          RELEASE_VERSION: ${{ steps.resolve-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
           # release-smoke.yml listens on `release: [published]` for


### PR DESCRIPTION
> 🚧 **Draft.** Fixes the v1.2.1 Release-workflow tag-detection bug without touching any existing tag. After this PR merges, retry the release with `gh workflow run release.yml --repo apet97/go-clockify --ref main -f tag=v1.2.1`. Does **not** delete or move any tag, does **not** retag rc.3, does **not** modify branch protection, does **not** reopen issue #78, does **not** declare paid-hosted/commercial readiness, does **not** claim official Clockify status.

## Failed run

[Release run 25635476567](https://github.com/apet97/go-clockify/actions/runs/25635476567) → [GoReleaser job](https://github.com/apet97/go-clockify/actions/runs/25635476567/job/75246453383) failed at `2026-05-10T17:47:43Z` with:

```
release failed after 1m45s
error=scm releases: failed to publish artifacts:
failed to upload clockify-mcp-fips-linux-x64:
POST https://uploads.github.com/repos/apet97/go-clockify/releases/320040573/assets?name=clockify-mcp-fips-linux-x64:
422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
```

Earlier in the same job log:

```
2026-05-10T17:47:33.8261598Z   • releasing                                    tag=v1.2.1-rc.3 repo=apet97/go-clockify
```

## Root cause

GoReleaser resolved the release tag as **`v1.2.1-rc.3`** while the workflow was actually triggered by a `v1.2.1` push. Both tags peel to the same commit `ce56414ae012c4a49d21ae0a319b178619c5966a` (v1.2.1 was cut from rc.3's peeled commit per the maintainer-approved community/self-hosted v1.2.1 plan), and GoReleaser's `git describe` / closest-tag fallback picked rc.3. Every asset upload then 422'd against the existing rc.3 release shell, the v1.2.1 GitHub Release was never created, the npm `1.2.1` package was never published, and Deploy cascaded to failure waiting for v1.2.1 assets to appear.

The Docker Image workflow succeeded independently (it uses `${{ github.ref_name }}` directly, not `git describe`), so `ghcr.io/apet97/go-clockify:1.2.1` is signed and live. The rc.3 GitHub Release was untouched (every upload returned 422 before any byte was overwritten).

## Fix

Pin the release tag explicitly inside the workflow:

1. **New `Resolve and validate release tag` step** runs before GoReleaser:
   - Reads `inputs.tag` on `workflow_dispatch`, otherwise `github.ref_name`.
   - Shape-guards against `vMAJOR.MINOR.PATCH[-suffix]`.
   - `git fetch --force --tags origin`, then `git rev-parse "${release_tag}^{commit}"` to confirm the tag exists and capture the peeled commit.
   - Pins the v1.2.1 peeled commit to `ce56414` per the launch-readiness ledger; mismatch fails closed.
   - Prints `git tag --points-at HEAD` for audit.
   - Writes `release_tag` and `release_commit` to `GITHUB_OUTPUT`.

2. **`GORELEASER_CURRENT_TAG`** added to the GoReleaser action's env, set to `${{ steps.resolve-release-tag.outputs.release_tag }}`. This is the canonical GoReleaser override that bypasses the `git describe` ambiguity.

3. **`RELEASE_VERSION`** in the npm-publish, reproducibility-dispatch, and release-smoke-dispatch steps switches from `${{ github.ref_name }}` to `${{ steps.resolve-release-tag.outputs.release_tag }}` so workflow_dispatch retries route to the correct tag and the same collision can't make npm publish a misnamed tarball.

4. **`workflow_dispatch`** with a required `tag: string` input. The on-tag-push trigger above cannot be re-fired without forbidden tag movement once a tag exists; this is the supported manual retry path. `actions/checkout@v6` now uses `ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}` so the dispatched build context matches the release artefact target.

Inputs are read via `env:` and quoted shell vars (`"${INPUT_TAG}"`, `"${REF_NAME}"`, `"${EVENT_NAME}"`) — no `${{ … }}` expansion inline in run scripts.

## Manual retry path (after this PR lands)

```sh
gh workflow run release.yml --repo apet97/go-clockify --ref main \
  -f tag=v1.2.1
```

`--ref main` selects the workflow file from `main` (which contains this fix); `-f tag=v1.2.1` picks the existing v1.2.1 git tag as the release target. The workflow does its own `git fetch --force --tags origin` + `git rev-parse` validation, and the v1.2.1 peeled-commit guard re-asserts the launch-readiness ledger's pinned commit before GoReleaser runs.

## What this PR does NOT do

- ❌ Does **NOT** delete or move the existing `v1.2.1` tag (annotated SHA `6dd3b78e`, peeled `ce56414`).
- ❌ Does **NOT** delete or move the existing `v1.2.1-rc.3` tag.
- ❌ Does **NOT** retag rc.3.
- ❌ Does **NOT** force-push anything.
- ❌ Does **NOT** modify branch protection on `main`.
- ❌ Does **NOT** reopen issue #78.
- ❌ Does **NOT** modify or remove any of the PR #88 packet docs.
- ❌ Does **NOT** claim official Clockify status.
- ❌ Does **NOT** declare paid-hosted/commercial readiness.
- ❌ Does **NOT** rerun Release as part of this PR — that happens AFTER merge via the manual retry above.

## Verifier results (all green)

- `actionlint -color=false .github/workflows/release.yml` → exit 0
- `ruby -ryaml YAML.load_file('.github/workflows/release.yml')` → OK
- `make doc-parity` → doc-parity / launch-review-ledger / launch-checklist-parity / launch-evidence-gate all OK
- `make launch-checklist-parity` → OK
- `make script-tests` → all 18 suites green
- `git diff --check` → exit 0

## Test plan

- [x] `actionlint` clean
- [x] YAML parses
- [x] All four local verifier suites green
- [x] Diff is workflow-only (1 file, +99/−3)
- [ ] Reviewer spot-check: `GORELEASER_CURRENT_TAG` and the three `RELEASE_VERSION` env vars all reference the same `steps.resolve-release-tag.outputs.release_tag`
- [ ] Reviewer spot-check: workflow_dispatch tag input is shape-guarded + existence-checked + peeled-commit-guarded for v1.2.1
- [ ] Post-merge: `gh workflow run release.yml --ref main -f tag=v1.2.1` produces a green Release run that creates the v1.2.1 GitHub Release with the full asset set
- [ ] Post-merge: Deploy retry passes the `Verify Release Assets` step
- [ ] Post-merge: npm `dist-tags.latest` updates to `1.2.1`