### PR TITLE
docs(launch): record v1.2.1 release evidence and accepted SAN exception

### DIFF
--- a/docs/launch-readiness-review-may-8.md
+++ b/docs/launch-readiness-review-may-8.md
@@ -1188,9 +1188,15 @@ post-rc.3-cycle closed/open gate state observed from
 `opus/lane6-final-integration-20260510` HEAD `3ee4847` (the merge of
 PR #85). It is written as a Lane 6 final integration audit on
 2026-05-10 and is the canonical pointer for what the rc.3 cycle did
-and did not close. **This audit does not declare the repository
-launch-ready. Final `v1.2.1` tag is post-Lane-6 and requires operator
-action.**
+and did not close. The maintainer cut `v1.2.1` from rc.3's peeled
+commit on 2026-05-10 for the community/self-hosted track; the
+canonical evidence is recorded in the "Closed gates with evidence
+anchors" row "v1.2.1 final tag cut and release published —
+community/self-hosted scope only" below and in the runbook §
+"v1.2.1 release evidence record (2026-05-10)". The paid-hosted /
+commercial track is **not** released; its five deferred follow-ups
+remain unmoved per "## Deferred paid-hosted/commercial follow-ups —
+not required for community/self-hosted v1.2.1" above.
 
 ### rc.3 cycle PR ledger (landed on `main`)
 
@@ -1228,6 +1234,7 @@ Lane 6 does not close them.
 | Group 7 — "All required workflows on `main` green" (mutation cron) — community/self-hosted v1.2.1 | Closed 2026-05-10 on the equivalent-source argument: scheduled `mutation.yml` cron run [25620978280](https://github.com/apet97/go-clockify/actions/runs/25620978280) (event=`schedule`, headSha `ab2a51e55b0e0116a3235b5254733999dca52e90`, completed/success at 2026-05-10T05:39:41Z) went green across all 6 matrix legs including `Mutation (internal/tools)` — the leg that previously timed out and cancelled every cron since the `2e7b6bd` "May 9 hardening" timeout fix landed. PR #87 (`ab2a51e`) and PR #88 (`2976e24`) modified only `scripts/**` and `docs/**`; `git diff --name-only ab2a51e^..main -- 'internal/**/*.go'` returns no entries. Mutation testing covers `internal/*` packages only, so the green cron on `ab2a51e` is byte-for-byte equivalent-source mutation evidence for both rc.3 (`ce56414`) and current main. This closure applies to the community/self-hosted `v1.2.1` release track only; the literal final-candidate-SHA evidence shape (a scheduled cron landing directly on the final `v1.2.1` SHA) remains a cadence wait that the next regular weekday cron will satisfy. Full evidence record: [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md) § "Mutation cron post-fix evidence — 2026-05-10". |
 | Group 7 — `make release-check` from clean checkouts on **Linux x64 + macOS arm64** | Closed 2026-05-10 once both host legs landed for `v1.2.1-rc.3` (peeled commit `ce56414ae012c4a49d21ae0a319b178619c5966a`). The macOS arm64 leg comes from the rc.3 `opus/group7-release-rc3-20260510` worktree (re-run after the transient TMPDIR concurrency failure cleared on its second invocation, evidence in the rc.3 record above). The Linux x64 leg comes from a Lane B Docker `linux/amd64` `golang:1.25-bookworm` clean-clone run between `2026-05-10T17:05:40Z` and `2026-05-10T17:21:48Z`: container kernel `Linux 04187e400898 6.10.14-linuxkit #1 SMP Sat May 17 08:28:57 UTC 2025 x86_64`, toolchain `go version go1.25.10 linux/amd64`, `make release-check` exit `0` with final line `release-check: OK — local pre-ship gate passed`. Full Linux x64 evidence shape (host info, command transcript, per-phase summary, log artefact paths) is in [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md) § "Linux x64 release-check evidence — v1.2.1-rc.3". |
 | Repository description + issue #28 | Both closed during the 2026-05-09 repo-state cleanup pass landed via PR #77 (`a5d5f75`). |
+| **v1.2.1 final tag cut and release published — community/self-hosted scope only** | Cut 2026-05-10 from rc.3 peeled commit `ce56414ae012c4a49d21ae0a319b178619c5966a`. Annotated tag SHA `6dd3b78e3900a01a31b1c5d5325173d72c5cf319`. GitHub Release published 2026-05-10T18:06:33Z (`name=v1.2.1`, `tagName=v1.2.1`, `isDraft=false`, `isPrerelease=false`, 46 assets). npm `@apet97/clockify-mcp-go` `version=1.2.1`, `dist-tags.latest=1.2.1`. Container image `ghcr.io/apet97/go-clockify:1.2.1` signed under SAN `release.yml@refs/tags/v1.2.1`. Reproducibility 9-leg matrix [25635947473](https://github.com/apet97/go-clockify/actions/runs/25635947473) match released bytes. Deploy [25635476552](https://github.com/apet97/go-clockify/actions/runs/25635476552) green end-to-end (Verify Release Assets / Staging / Verify Live Contract / Production). The release.yml run that produced the v1.2.1 GitHub Release was a maintainer-approved `workflow_dispatch` retry ([25635880549](https://github.com/apet97/go-clockify/actions/runs/25635880549)) with `tag=v1.2.1` after PR #92 (`2766b39`) pinned `GORELEASER_CURRENT_TAG`; the original tag-push run failed because GoReleaser misread the tag as `v1.2.1-rc.3`. **Accepted release-smoke SAN exception**: v1.2.1 release-asset cosign signatures carry SAN `release.yml@refs/heads/main` (the manual-retry path) instead of `release.yml@refs/tags/v1.2.1`; signatures are valid Fulcio identities, full operator-side verification command and exception preconditions are recorded in [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md) § "v1.2.1 release evidence record (2026-05-10)". This closure is for the **community/self-hosted v1.2.1** track only; paid-hosted/commercial follow-ups remain deferred. |
 
 ### Open gates with exact next-step action
 
@@ -1328,28 +1335,33 @@ on 2026-05-10 against HEAD `3ee4847` (= `main` post-PR #85):
 
 ### Non-claim
 
-This audit does not declare the repository launch-ready. Final
-`v1.2.1` tag is post-Lane-6 and requires operator action. As of
-2026-05-10 there are **zero** active community/self-hosted release
-blockers in this ledger: the Group 7 two-host `make release-check`
-gate closed once the Linux x64 leg landed (see the rc.3 evidence
-record and the new "Linux x64 release-check evidence — v1.2.1-rc.3"
-subsection in the runbook), and the Group 7 "All required workflows
-on `main` green" (mutation cron) gate closed on the equivalent-source
-argument also captured above. The forward-looking npm publish path
-row is informational on the next publish, not a blocker for the
-current rc.3 → final v1.2.1 cut. The five paid-hosted / commercial
-follow-ups (paid-hosted external security review, DPA / privacy /
-trademark approval, paid-commercial RLS, cross-replica hosted HTTP
-quotas, plus the trademark-coupled `clockify://` URI / gRPC
-service-name branding review) are explicitly **deferred** under
-"## Deferred paid-hosted/commercial follow-ups — not required for
-community/self-hosted v1.2.1" and do **not** block the
-community/self-hosted `v1.2.1` cut so long as the release notes and
-public docs keep the project framed as community/self-hosted and do
-not claim official Clockify status. Cutting `v1.2.1` is still a
-maintainer action; this audit only records that the active
-community/self-hosted blocker list is empty.
+This audit does not declare paid-hosted/commercial readiness and
+does not claim official Clockify status. As of 2026-05-10 there are
+**zero** active community/self-hosted release blockers in this
+ledger: the Group 7 two-host `make release-check` gate closed once
+the Linux x64 leg landed (see the rc.3 evidence record and the
+"Linux x64 release-check evidence — v1.2.1-rc.3" subsection in the
+runbook), the Group 7 "All required workflows on `main` green"
+(mutation cron) gate closed on the equivalent-source argument also
+captured above, and `v1.2.1` itself was cut and published from rc.3's
+peeled commit `ce56414ae012c4a49d21ae0a319b178619c5966a` later that
+same day (annotated tag SHA `6dd3b78e3900a01a31b1c5d5325173d72c5cf319`,
+GitHub Release `isDraft=false`, `isPrerelease=false`, 46 assets, npm
+`dist-tags.latest=1.2.1`, Reproducibility 9-leg green, Deploy
+end-to-end green). The release.yml SAN exception covering the
+maintainer-approved manual-dispatch retry is documented in the
+runbook record. The forward-looking npm publish path row is
+informational on the next publish, not a blocker. The five
+paid-hosted / commercial follow-ups (paid-hosted external security
+review, DPA / privacy / trademark approval, paid-commercial RLS,
+cross-replica hosted HTTP quotas, plus the trademark-coupled
+`clockify://` URI / gRPC service-name branding review) remain
+explicitly **deferred** under "## Deferred paid-hosted/commercial
+follow-ups — not required for community/self-hosted v1.2.1" and do
+**not** block the community/self-hosted `v1.2.1` release that just
+shipped, so long as the release notes and public docs keep the
+project framed as community/self-hosted and do not claim official
+Clockify status.
 
 ## Verification used for this pass
 

--- a/docs/runbooks/release-candidate-evidence.md
+++ b/docs/runbooks/release-candidate-evidence.md
@@ -645,3 +645,115 @@ Closure scope:
 - **Still pending in literal SHA-binding form** for any future paid-hosted / commercial track that requires a scheduled cron to land directly on the SHA `v1.2.1` (or the next paid-hosted candidate) is cut from. That cadence wait is hours, not days; the next regular weekday scheduled cron will satisfy it.
 
 This record does not declare the repository launch-ready, does not retag `v1.2.1-rc.3` or cut `v1.2.1`, does not modify branch protection, and does not tick checkboxes outside the `mutation.yml`-bound row in the launch-readiness ledger.
+
+## v1.2.1 release evidence record (2026-05-10)
+
+Scope: **community/self-hosted v1.2.1 only.** This record captures the maintainer-approved final cut from the rc.3 peeled commit. It does not claim paid-hosted/commercial readiness and does not assert official Clockify status. The five paid-hosted / commercial follow-ups remain deferred per "## Deferred paid-hosted/commercial follow-ups — not required for community/self-hosted v1.2.1" in [`docs/launch-readiness-review-may-8.md`](../launch-readiness-review-may-8.md).
+
+### Tag and commit
+
+| Field | Value |
+|---|---|
+| Final tag | `v1.2.1` |
+| Annotated tag SHA | `6dd3b78e3900a01a31b1c5d5325173d72c5cf319` |
+| Peeled commit | `ce56414ae012c4a49d21ae0a319b178619c5966a` (= `v1.2.1-rc.3` peeled commit) |
+| Tag-cut command | `git tag -a v1.2.1 ce56414ae012c4a49d21ae0a319b178619c5966a -m "v1.2.1"` |
+| Tag-push timestamp | 2026-05-10T17:45 (operator host) |
+| `v1.2.1-rc.3` retagged? | **No.** Pre-existing rc.3 release with 47 prerelease assets is intact and untouched. |
+
+### Workflow runs that produced v1.2.1
+
+| Workflow | Run | Trigger | Conclusion | Note |
+|---|---|---|---|---|
+| Release | [25635476567](https://github.com/apet97/go-clockify/actions/runs/25635476567) | `push` (tag v1.2.1) | ❌ failure | GoReleaser tag-detection bug: resolved tag as `v1.2.1-rc.3` and 422'd against the existing rc.3 release shell. No assets reached GitHub. v1.2.1 GitHub Release was never created by this run. |
+| Release (retry) | [25635880549](https://github.com/apet97/go-clockify/actions/runs/25635880549) | `workflow_dispatch` (`tag=v1.2.1`, `--ref main`) | ✅ success | Ran with PR #92 (`2766b39`) on `main` so `GORELEASER_CURRENT_TAG=v1.2.1` was pinned and the resolve/validate step pinned the peeled commit to `ce56414`. Created the v1.2.1 GitHub Release and uploaded all 46 release assets. |
+| Docker Image | [25635476543](https://github.com/apet97/go-clockify/actions/runs/25635476543) | `push` (tag v1.2.1) | ✅ success | `ghcr.io/apet97/go-clockify:1.2.1` image signed with cosign keyless under SAN `release.yml@refs/tags/v1.2.1`. |
+| Reproducibility | [25635947473](https://github.com/apet97/go-clockify/actions/runs/25635947473) | `workflow_dispatch` (auto-fired by Release) | ✅ success | 9-leg matrix (5 default + 4 FIPS targets) all match released bytes. |
+| Deploy | [25635476552](https://github.com/apet97/go-clockify/actions/runs/25635476552) (rerun) | `push` (tag v1.2.1) | ✅ success | All four jobs green: Verify Release Assets / Deploy to Staging / Verify Live Contract / Deploy to Production. |
+| Release smoke | [25635948010](https://github.com/apet97/go-clockify/actions/runs/25635948010) | `workflow_dispatch` (auto-fired by Release retry) | ❌ failure | cosign-verify SAN regex pinned to `^…release.yml@refs/tags/.*$` rejects the manual-retry signature SAN of `release.yml@refs/heads/main`. Documented exception below; not treated as a v1.2.1 launch blocker. |
+
+### GitHub Release artefacts
+
+| Field | Value |
+|---|---|
+| URL | <https://github.com/apet97/go-clockify/releases/tag/v1.2.1> |
+| `tagName` | `v1.2.1` |
+| `name` | `v1.2.1` |
+| `isDraft` | `false` |
+| `isPrerelease` | `false` |
+| `publishedAt` | 2026-05-10T18:06:33Z |
+| Asset count | **46** (matches the structural contract: 15 binaries + 15 SPDX SBOMs + 15 sigstore bundles + `SHA256SUMS.txt`) |
+| Asset-count check | `gh release view v1.2.1 --json assets --jq '.assets | length'` → `46`. The Release retry's in-workflow `Verify release asset count` step (`bash scripts/check-release-assets.sh` against the goreleaser `dist/` directory) passed; the workflow only reaches the upload phase if that count matches. |
+
+### npm wrapper package
+
+| Field | Value |
+|---|---|
+| Package | `@apet97/clockify-mcp-go` |
+| `version` | `1.2.1` |
+| `dist-tags.latest` | `1.2.1` |
+| `dist-tags.rc` | `1.2.1-rc.3` (preserved from the rc.3 publish) |
+| Verifier | `bash scripts/check-launch-external-status.sh --candidate-sha ce56414… --expected-npm-version v1.2.1 --fail-open` reports `[closed] npm publish path: registry version and latest dist-tag match expected 1.2.1`. |
+
+### Container image
+
+| Field | Value |
+|---|---|
+| Image | `ghcr.io/apet97/go-clockify:1.2.1` |
+| Cosign certificate identity | `https://github.com/apet97/go-clockify/.github/workflows/docker-image.yml@refs/tags/v1.2.1` |
+| OIDC issuer | `https://token.actions.githubusercontent.com` |
+| Note | The Docker Image workflow ran on the original tag-push event (not the manual retry), so its OIDC SAN is the canonical `refs/tags/v1.2.1`. |
+
+### Reproducibility evidence
+
+Run [25635947473](https://github.com/apet97/go-clockify/actions/runs/25635947473) (workflow_dispatch on `v1.2.1`) reports all 9 matrix legs `success`. Each leg rebuilds a binary from the v1.2.1 source tree under `GOTOOLCHAIN=go1.25.10`, applies the goreleaser `mod_timestamp` setting, and SHA256-compares the bytes against the released asset of the same name. Operators reproducing locally must reuse the exact toolchain pin; see `docs/verification.md`.
+
+### Deploy chain
+
+Run 25635476552 (rerun via `gh run rerun 25635476552 --failed` after PR #92 fixed the upstream Release): `Verify Release Assets` → `Deploy to Staging` → `Verify Live Contract` → `Deploy to Production` all green, end-to-end. The Deploy workflow's verification path accepted the manual-retry SAN.
+
+### release-smoke manual-dispatch SAN exception
+
+**Accepted exception for v1.2.1 only.** The `release-smoke.yml` cosign-verify step pins the certificate identity regex to `^https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/tags/.*$`. Because the v1.2.1 Release ran via `workflow_dispatch` from `--ref main` (the only path that does not require forbidden tag movement after the v1.2.1 tag was already pushed), Fulcio issued the OIDC certificate with SAN `release.yml@refs/heads/main`. The signatures on the v1.2.1 release assets are valid Fulcio-issued sigstore identities — they simply identify the workflow context as `refs/heads/main` instead of `refs/tags/v1.2.1`.
+
+This exception is accepted **only for v1.2.1**, and only on the strict precondition that:
+
+- the `Resolve and validate release tag` step (PR #92) executed inside run [25635880549](https://github.com/apet97/go-clockify/actions/runs/25635880549) and pinned `GORELEASER_CURRENT_TAG=v1.2.1`;
+- the same step re-fetched tags, ran `git rev-parse v1.2.1^{commit}`, and confirmed the peeled commit equals `ce56414ae012c4a49d21ae0a319b178619c5966a`;
+- the v1.2.1 GitHub Release name and tag both equal `v1.2.1`;
+- the rc.3 release was not modified (still 47 prerelease assets, `isPrerelease=true`).
+
+Operators verifying the v1.2.1 binaries should use:
+
+```sh
+cosign verify-blob \
+  --bundle <binary>.sigstore.json \
+  --certificate-identity 'https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/heads/main' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  <binary>
+```
+
+Note the **literal `--certificate-identity`** (not `--certificate-identity-regexp`) so the SAN exception does not silently widen to any other branch identity. Future releases that follow a clean tag-push path will revert to the canonical `refs/tags/<tag>` SAN; this exception applies only to the v1.2.1 retry artefacts.
+
+The cascading `Validate doctor strict evidence files` failure in run 25635948010 (`release-doctor-postgres-ok.txt is missing or empty`) is downstream of the cosign-verify failure — release-smoke aborts evidence collection on the verify step. The Group 6 doctor-strict evidence captured during rc.3 ([release-smoke run 25616925600](https://github.com/apet97/go-clockify/actions/runs/25616925600)) remains the canonical doctor-strict reference for the v1.2.1 codebase, since rc.3 (`ce56414`) and v1.2.1 (`ce56414`) peel to the same commit.
+
+### Hard-rule compliance
+
+- ❌ Did **NOT** delete or move `v1.2.1` (annotated SHA `6dd3b78e`).
+- ❌ Did **NOT** delete or move `v1.2.1-rc.3` (rc.3 release with 47 prerelease assets remains intact).
+- ❌ Did **NOT** retag rc.3.
+- ❌ Did **NOT** force-push.
+- ❌ Did **NOT** modify branch protection.
+- ❌ Did **NOT** reopen issue #78.
+- ❌ Did **NOT** modify or remove any of the PR #88 packet docs.
+- ❌ Did **NOT** declare paid-hosted/commercial readiness.
+- ❌ Did **NOT** claim official Clockify status.
+- ❌ Did **NOT** modify the v1.2.1 release artefacts; the SAN exception is documentation about how to verify them, not a re-publish.
+
+### What this record does not do
+
+- Does not declare the repository launch-ready for any track other than community/self-hosted v1.2.1.
+- Does not authorise a public-visibility flip beyond the existing public posture; the repo was already public.
+- Does not retag, recreate, or move any tag (final or rc).
+- Does not re-promote any of the five deferred paid-hosted/commercial follow-ups to active blockers.
+- Does not absolve the next release of the canonical `refs/tags/<tag>` SAN expectation; the exception above is bounded to v1.2.1 only.


### PR DESCRIPTION
> 🚧 **Draft.** Records the maintainer-approved final v1.2.1 cut (community/self-hosted scope only) and documents the accepted manual-dispatch SAN exception that was structurally required to retry Release without forbidden tag movement. **No release artefacts are modified by this PR** — it is documentation about how to verify them. Does **not** delete or move any tag, does **not** retag rc.3, does **not** modify branch protection, does **not** reopen issue #78, does **not** declare paid-hosted/commercial readiness, does **not** claim official Clockify status.

## v1.2.1 release facts

| Field | Value |
|---|---|
| Final tag | `v1.2.1` |
| Annotated tag SHA | `6dd3b78e3900a01a31b1c5d5325173d72c5cf319` |
| Peeled commit | `ce56414ae012c4a49d21ae0a319b178619c5966a` (= `v1.2.1-rc.3` peeled commit) |
| GitHub Release URL | https://github.com/apet97/go-clockify/releases/tag/v1.2.1 |
| `name` / `tagName` | `v1.2.1` / `v1.2.1` |
| `isDraft` / `isPrerelease` | `false` / `false` |
| `publishedAt` | 2026-05-10T18:06:33Z |
| Asset count | 46 (matches the structural contract) |
| npm `version` / `dist-tags.latest` | `1.2.1` / `1.2.1` |
| Container image | `ghcr.io/apet97/go-clockify:1.2.1` (signed under `release.yml@refs/tags/v1.2.1`) |
| Reproducibility | [25635947473](https://github.com/apet97/go-clockify/actions/runs/25635947473) — 9-leg matrix all match released bytes |
| Deploy → Staging → Production | [25635476552](https://github.com/apet97/go-clockify/actions/runs/25635476552) — green end-to-end |

## Accepted release-smoke SAN exception (v1.2.1 only)

The Release workflow that produced v1.2.1's GitHub Release was the maintainer-approved manual retry [25635880549](https://github.com/apet97/go-clockify/actions/runs/25635880549) (workflow_dispatch from `--ref main` with `tag=v1.2.1`). The retry was structurally required because:

- The original tag-push Release run [25635476567](https://github.com/apet97/go-clockify/actions/runs/25635476567) failed when GoReleaser misread the tag as `v1.2.1-rc.3` (final and rc tags peel to the same commit; goreleaser's `git describe` ambiguity picked rc.3) and 422'd against the existing rc.3 release shell.
- PR #92 (`2766b39`) fixed the root cause by pinning `GORELEASER_CURRENT_TAG` and adding a resolve/validate step inside release.yml.
- Once the fix landed on `main`, the retry could only run via `workflow_dispatch` because re-firing the on-tag-push trigger would have required forbidden tag movement.

The retry's OIDC certificate carries SAN `release.yml@refs/heads/main` instead of `release.yml@refs/tags/v1.2.1`. The `release-smoke.yml` cosign-verify step pins the SAN regex to `^…release.yml@refs/tags/.*$` and so rejects the retry signature ([release-smoke run 25635948010](https://github.com/apet97/go-clockify/actions/runs/25635948010) failed). The signatures are valid Fulcio identities — only the regex convention rejects them.

This PR records the exception **for v1.2.1 only**, on the strict precondition that:

- the new resolve/validate step in PR #92 ran inside the retry (run 25635880549) and pinned `GORELEASER_CURRENT_TAG=v1.2.1`;
- the same step re-fetched tags, ran `git rev-parse v1.2.1^{commit}`, and confirmed the peeled commit equals `ce56414ae012c4a49d21ae0a319b178619c5966a`;
- the v1.2.1 GitHub Release `name` and `tagName` both equal `v1.2.1`;
- the rc.3 release was not modified (still 47 prerelease assets, `isPrerelease=true`).

Operators verifying v1.2.1 binaries should use:

```sh
cosign verify-blob \
  --bundle <binary>.sigstore.json \
  --certificate-identity 'https://github.com/apet97/go-clockify/.github/workflows/release.yml@refs/heads/main' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  <binary>
```

(literal `--certificate-identity`, not `--certificate-identity-regexp`, so the exception cannot silently widen).

The container image `ghcr.io/apet97/go-clockify:1.2.1` and Docker Image workflow ran on the original tag-push event and verify with the canonical `release.yml@refs/tags/v1.2.1` SAN — operators verifying the image should keep the existing pinned identity.

Future releases that follow a clean tag-push path will revert to the canonical `release.yml@refs/tags/<tag>` SAN; this exception is bounded to v1.2.1.

## What changed

- `docs/runbooks/release-candidate-evidence.md`
  - New "v1.2.1 release evidence record (2026-05-10)" section appended (≈110 lines): tag/commit, six workflow runs, GitHub Release shape, npm, container image, Reproducibility, Deploy chain, the SAN exception with operator-side cosign verification command, hard-rule compliance, non-claim block.
- `docs/launch-readiness-review-may-8.md`
  - "Closed gates with evidence anchors" gains the row "v1.2.1 final tag cut and release published — community/self-hosted scope only" referencing the runbook record.
  - "Final integration audit" intro paragraph and "Non-claim" paragraph rewritten to record the v1.2.1 cut as community/self-hosted-only and preserve the paid-hosted/commercial deferral.

## What this PR does NOT do

- ❌ Does **NOT** delete or move the existing `v1.2.1` tag (annotated SHA `6dd3b78e`).
- ❌ Does **NOT** delete or move the existing `v1.2.1-rc.3` tag.
- ❌ Does **NOT** retag rc.3.
- ❌ Does **NOT** force-push.
- ❌ Does **NOT** modify branch protection.
- ❌ Does **NOT** reopen issue #78.
- ❌ Does **NOT** modify or remove any of the PR #88 packet docs.
- ❌ Does **NOT** declare paid-hosted/commercial readiness.
- ❌ Does **NOT** claim official Clockify status.
- ❌ Does **NOT** modify the v1.2.1 release artefacts.
- ❌ Does **NOT** widen `release-smoke.yml`'s SAN regex; that is an optional follow-up the maintainer can address separately.

## Verifier results (all green)

- `make doc-parity` → doc-parity / launch-review-ledger / launch-checklist-parity / launch-evidence-gate all OK
- `make launch-checklist-parity` → OK
- `make script-tests` → all 18 suites green
- `git diff --check` → exit 0
- `gh release view v1.2.1 --json …` → `name=v1.2.1`, `isPrerelease=false`, 46 assets
- `npm view @apet97/clockify-mcp-go version dist-tags --json` → `version=1.2.1`, `dist-tags.latest=1.2.1`
- `bash scripts/check-launch-external-status.sh --candidate-sha ce56414… --expected-npm-version v1.2.1 --fail-open` → `[closed] npm publish path: registry version and latest dist-tag match expected 1.2.1` (the remaining `[open]` lines map to documented closures: Group-1 canonical-SHA quirk, equivalent-source mutation cron, codeql/dependency-review/semgrep SHA-binding nuances on the post-cut docs commits)

## Test plan

- [x] `make doc-parity` clean
- [x] `make launch-checklist-parity` clean
- [x] `make script-tests` clean (18/18 suites)
- [x] `git diff --check` clean
- [x] Diff is docs-only (2 files)
- [x] All "exception preconditions" are factual against the actual run state
- [ ] Reviewer spot-check: SAN exception is bounded to v1.2.1 and clearly states future releases revert to the canonical regex
- [ ] Reviewer spot-check: the "Closed gates" row pointer matches the runbook section name verbatim

## Related

- PR #90 (`da7f931`) — paid-hosted scope correction
- PR #89 (`637157d`) — mutation cron equivalent-source closure
- PR #91 (`5206477`) — Linux x64 release-check evidence
- PR #92 (`2766b39`) — release.yml `GORELEASER_CURRENT_TAG` pin + workflow_dispatch retry path
- v1.2.1 release: https://github.com/apet97/go-clockify/releases/tag/v1.2.1