### PR TITLE
chore(release-smoke): support canonical and manual-retry verification modes

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -63,6 +63,43 @@ on:
         description: "Release tag to verify (e.g. v1.2.0). Defaults to latest if empty."
         required: false
         default: ""
+      verification_mode:
+        description: |
+          Cosign certificate-identity verification mode.
+
+          - canonical (default): expect signatures from a clean
+            tag-push run of release.yml — i.e. SAN
+            `release.yml@refs/tags/<tag>`, matched via
+            `--certificate-identity-regexp`. Use this for every
+            normal release.
+          - manual-retry-exception: explicit, narrow opt-in for an
+            already-released tag whose binaries were signed under a
+            non-tag SAN because the release.yml retry had to run via
+            `workflow_dispatch` from a branch (the only path that
+            does not require forbidden tag movement once a tag
+            exists). The exception is bounded by
+            `expected_workflow_ref` below; the workflow uses literal
+            `--certificate-identity` (NOT regex) so the SAN cannot
+            silently widen to any other branch identity. Selecting
+            this mode emits a loud `::notice::` annotation in the
+            run log and is documented in
+            `docs/runbooks/release-candidate-evidence.md`.
+        required: false
+        default: canonical
+        type: choice
+        options:
+          - canonical
+          - manual-retry-exception
+      expected_workflow_ref:
+        description: |
+          Required iff verification_mode=manual-retry-exception.
+          Must be a fully-qualified git ref the SAN should equal,
+          e.g. `refs/heads/main` or `refs/tags/v1.2.1`. Used to
+          construct the literal cosign --certificate-identity:
+          `https://github.com/<repo>/.github/workflows/release.yml@<expected_workflow_ref>`.
+          Empty / shape-invalid fails closed.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -162,6 +199,88 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Verifying release artifacts for ${tag}"
 
+      - name: Resolve cosign verification identity
+        id: ident
+        # Two explicit modes:
+        #
+        #   1. canonical — release/schedule events and the default
+        #      workflow_dispatch path. Verifies the release-asset
+        #      signatures came from a clean tag-push run of
+        #      release.yml, by matching SAN against the regex
+        #      `release.yml@refs/tags/.*`. This is the strict default
+        #      and the only path automated triggers ever take.
+        #
+        #   2. manual-retry-exception — explicit, narrow opt-in only
+        #      available on workflow_dispatch. Verifies a known
+        #      already-released tag whose binaries were signed under
+        #      `release.yml@refs/heads/<branch>` because the
+        #      release.yml retry had to run via workflow_dispatch
+        #      from a branch (the only path that does not require
+        #      forbidden tag movement once a tag exists). Uses
+        #      literal `--certificate-identity` (NOT regex) so the
+        #      SAN cannot silently widen to any other branch.
+        #
+        # Mode is captured as `mode` (`regex` | `literal`) and the
+        # SAN value as `value`. Consumers (the cosign verify-blob
+        # steps below) branch on `mode` and pass `value` as either
+        # `--certificate-identity-regexp` or `--certificate-identity`.
+        # The mode difference must be loud and traceable in the run
+        # log; the `manual-retry-exception` path emits a `::notice::`
+        # annotation that names the exception preconditions.
+        env:
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_MODE: ${{ github.event.inputs.verification_mode }}
+          INPUT_REF: ${{ github.event.inputs.expected_workflow_ref }}
+        run: |
+          set -euo pipefail
+
+          canonical_regex="^https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/.*\$"
+
+          # Default: canonical. Only workflow_dispatch can flip to
+          # manual-retry-exception, and only with an explicit
+          # `verification_mode=manual-retry-exception` AND a non-empty
+          # `expected_workflow_ref`. Empty/missing input or the
+          # canonical sentinel both stay on canonical.
+          mode="regex"
+          value="${canonical_regex}"
+          chosen="canonical"
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ "${INPUT_MODE:-canonical}" = "manual-retry-exception" ]; then
+            if [ -z "${INPUT_REF:-}" ]; then
+              echo "::error::manual-retry-exception requires expected_workflow_ref to be set"
+              exit 1
+            fi
+            # Shape guard: must be a fully-qualified git ref under
+            # refs/heads/ or refs/tags/, with the ref name itself
+            # restricted to a simple character set so the value can
+            # be embedded in a cosign literal --certificate-identity
+            # without re-escaping. Refuses absolute URLs, wildcards,
+            # regex metacharacters, and short ref names.
+            #
+            # Whitelist match against:
+            #     refs/(heads|tags)/[A-Za-z0-9._/-]+
+            # via grep -E (case glob bracket expressions cannot
+            # express character classes that strictly enough across
+            # shells).
+            if ! printf '%s' "${INPUT_REF}" | grep -Eq '^refs/(heads|tags)/[A-Za-z0-9._/-]+$'; then
+              echo "::error::expected_workflow_ref must match refs/(heads|tags)/[A-Za-z0-9._/-]+ (no spaces, no shell or regex metacharacters), got: ${INPUT_REF}"
+              exit 1
+            fi
+            mode="literal"
+            value="https://github.com/${REPO}/.github/workflows/release.yml@${INPUT_REF}"
+            chosen="manual-retry-exception"
+            echo "::notice title=Manual-retry SAN exception in effect::release-smoke is verifying signatures with literal --certificate-identity '${value}'. This is an explicit opt-in (verification_mode=manual-retry-exception, expected_workflow_ref=${INPUT_REF}); see docs/runbooks/release-candidate-evidence.md for the bounded preconditions. Future tag-push releases revert to canonical regex automatically."
+          fi
+
+          {
+            echo "mode=${mode}"
+            echo "value=${value}"
+            echo "chosen=${chosen}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Verification mode: ${chosen} (cosign ${mode})"
+          echo "Verification SAN:  ${value}"
+
       - name: Download linux-x64 binary + sigstore bundle
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -248,18 +367,40 @@ jobs:
       - name: Verify cosign keyless signature on binary
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          IDENT_MODE: ${{ steps.ident.outputs.mode }}
+          IDENT_VALUE: ${{ steps.ident.outputs.value }}
         run: |
           set -euo pipefail
-          # The certificate identity is the goreleaser signing step
-          # running inside .github/workflows/release.yml at the tag.
-          # Pin the issuer to GitHub's OIDC endpoint and use a regex
-          # that matches any tag so the same workflow tracks future
-          # releases without edit.
-          cosign verify-blob \
-            --bundle artifacts/clockify-mcp-linux-x64.sigstore.json \
-            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/.*$" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            artifacts/clockify-mcp-linux-x64
+          # Identity comes from the `Resolve cosign verification
+          # identity` step:
+          #   - canonical mode    → IDENT_MODE=regex, IDENT_VALUE is the
+          #     `release.yml@refs/tags/.*` regex.
+          #   - manual-retry mode → IDENT_MODE=literal, IDENT_VALUE is
+          #     the explicit non-tag SAN documented for the bounded
+          #     exception (see runbook).
+          # Branching on IDENT_MODE keeps the two modes traceable in
+          # the verifier output without papering over the regex/literal
+          # difference in cosign's CLI.
+          case "$IDENT_MODE" in
+            regex)
+              cosign verify-blob \
+                --bundle artifacts/clockify-mcp-linux-x64.sigstore.json \
+                --certificate-identity-regexp "$IDENT_VALUE" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+                artifacts/clockify-mcp-linux-x64
+              ;;
+            literal)
+              cosign verify-blob \
+                --bundle artifacts/clockify-mcp-linux-x64.sigstore.json \
+                --certificate-identity "$IDENT_VALUE" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+                artifacts/clockify-mcp-linux-x64
+              ;;
+            *)
+              echo "::error::unexpected IDENT_MODE=${IDENT_MODE}"
+              exit 1
+              ;;
+          esac
 
       - name: Smoke-test doctor --strict --check-backends on Postgres release binary
         env:
@@ -318,19 +459,38 @@ jobs:
       - name: Verify cosign keyless signature on Postgres binary
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          IDENT_MODE: ${{ steps.ident.outputs.mode }}
+          IDENT_VALUE: ${{ steps.ident.outputs.value }}
         run: |
           set -euo pipefail
           # Postgres-tagged binaries are signed by the same goreleaser
           # cosign-keyless step in release.yml that signs the default
-          # and FIPS matrices, so the certificate identity regex is
-          # identical. A signature mismatch here would indicate the
-          # postgres archive was added without flowing through the
-          # signs.cosign-keyless block in .goreleaser.yaml.
-          cosign verify-blob \
-            --bundle artifacts/clockify-mcp-postgres-linux-x64.sigstore.json \
-            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/.*$" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            artifacts/clockify-mcp-postgres-linux-x64
+          # and FIPS matrices, so the certificate identity is identical
+          # to the default-binary check above. A signature mismatch
+          # here would indicate the postgres archive was added without
+          # flowing through the signs.cosign-keyless block in
+          # .goreleaser.yaml. Branches on IDENT_MODE for the same
+          # canonical-vs-manual-retry reason as the default-binary step.
+          case "$IDENT_MODE" in
+            regex)
+              cosign verify-blob \
+                --bundle artifacts/clockify-mcp-postgres-linux-x64.sigstore.json \
+                --certificate-identity-regexp "$IDENT_VALUE" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+                artifacts/clockify-mcp-postgres-linux-x64
+              ;;
+            literal)
+              cosign verify-blob \
+                --bundle artifacts/clockify-mcp-postgres-linux-x64.sigstore.json \
+                --certificate-identity "$IDENT_VALUE" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+                artifacts/clockify-mcp-postgres-linux-x64
+              ;;
+            *)
+              echo "::error::unexpected IDENT_MODE=${IDENT_MODE}"
+              exit 1
+              ;;
+          esac
 
       - name: Validate doctor strict evidence files
         if: always()

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -224,6 +224,44 @@ stays open until the next green run closes it automatically. There is
 no Slack, no email, no polling dashboard — the open issue is the
 exclusive failure signal.
 
+## Two cosign-verify modes (canonical vs manual-retry exception)
+
+The release-smoke workflow uses two explicit verification modes, set
+via the `verification_mode` `workflow_dispatch` input:
+
+1. **canonical** (default for every event including
+   `workflow_dispatch`). The cosign certificate-identity check uses
+   the regex
+   `^https://github.com/<owner>/<repo>/.github/workflows/release.yml@refs/tags/.*$`
+   so it tracks every future tag-push release without edit. This is
+   the only mode `release` and `schedule` events ever take.
+
+2. **manual-retry-exception** (workflow_dispatch only, opt-in,
+   bounded). For an already-released tag whose binaries were signed
+   under a non-tag SAN because the `release.yml` retry had to run via
+   `workflow_dispatch` from a branch (the only path that does not
+   require forbidden tag movement once a tag exists), this mode
+   accepts the literal SAN supplied via `expected_workflow_ref`
+   (e.g. `refs/heads/main`). The workflow uses cosign's literal
+   `--certificate-identity` (NOT `--certificate-identity-regexp`) so
+   the SAN cannot silently widen to any other branch identity. The
+   mode emits a loud `::notice::` annotation in the run log naming
+   the exception and pointing at the runbook record.
+
+   `expected_workflow_ref` is shape-guarded against
+   `refs/(heads|tags)/[A-Za-z0-9._/-]+` and the workflow fails closed
+   if it is empty or contains shell/regex metacharacters.
+
+A clean tag-push release reverts to **canonical** automatically; the
+exception mode is opt-in per dispatch and never persists. The
+historical `v1.2.1` exception (signed under `refs/heads/main` because
+the GoReleaser tag-detection bug forced a workflow_dispatch retry
+after the v1.2.1 tag was already pushed) is recorded as a frozen
+historical entry in
+[`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+§ "v1.2.1 release evidence record (2026-05-10)" and is unaffected by
+this two-mode framing.
+
 ## Related documents
 
 - [`SECURITY.md`](../SECURITY.md) — full list of release artifacts


### PR DESCRIPTION
> 🟢 **Post-release cleanup only.** Does not touch tag `v1.2.1`, any release artifact, the v1.2.1 historical evidence record, branch protection, issue #78, the PR #88 packet docs, or any other workflow. Adds explicit two-mode cosign verification to `release-smoke.yml` so future maintainers can opt into a bounded SAN exception per-dispatch instead of relying on documentation alone.

## Why

The cosign verify-blob steps in `release-smoke.yml` previously pinned the certificate-identity check to a single regex, `release.yml@refs/tags/.*`. That regex is correct for every clean tag-push release, but it has no way to express the bounded exception that v1.2.1 needed — a release whose binaries were signed under `release.yml@refs/heads/main` because the GoReleaser tag-detection bug (PR #92) forced a workflow_dispatch retry after the v1.2.1 tag was already pushed and forbidden tag movement was the only alternative. v1.2.1's historical record in [`docs/runbooks/release-candidate-evidence.md`](https://github.com/apet97/go-clockify/blob/main/docs/runbooks/release-candidate-evidence.md) § "v1.2.1 release evidence record (2026-05-10)" documents the exception with operator-side cosign verification commands; this PR makes the workflow itself express the same distinction.

## What changed

- `.github/workflows/release-smoke.yml`
  - **New `workflow_dispatch` inputs**:
    - `verification_mode` (choice, default `canonical`, second value `manual-retry-exception`)
    - `expected_workflow_ref` (string, default empty; required iff `verification_mode=manual-retry-exception`)
  - **New "Resolve cosign verification identity" step** that maps event + inputs to:
    - `outputs.mode` ∈ {`regex`, `literal`}
    - `outputs.value` (the SAN regex or literal SAN)
    - For `release` and `schedule` events: ignores inputs entirely; always writes the canonical regex.
    - For `workflow_dispatch` + canonical mode (default): same as automated events.
    - For `workflow_dispatch` + `manual-retry-exception`: requires non-empty `expected_workflow_ref`, shape-guards it against `refs/(heads|tags)/[A-Za-z0-9._/-]+` (no spaces, no shell or regex metacharacters), constructs the literal SAN, and emits a loud `::notice::` annotation naming the exception and pointing at the runbook.
  - **Both cosign verify-blob steps** (default linux-x64 + Postgres linux-x64) now branch on `IDENT_MODE`, passing `--certificate-identity-regexp` when `regex` and `--certificate-identity` when `literal`. The container-image cosign verify (against `docker-image.yml`) is unchanged because `docker-image.yml` is not in the same retry path.
- `docs/verification.md`
  - New "Two cosign-verify modes (canonical vs manual-retry exception)" subsection in the "What the automated smoke checks" area, describing both modes, the shape guard, and the loud notice. References the v1.2.1 historical exception as a frozen entry.

## Behavior matrix

| Event | `verification_mode` | `expected_workflow_ref` | Resolved cosign arg |
|---|---|---|---|
| `release` (any tag) | n/a (input ignored) | n/a | `--certificate-identity-regexp ^…release.yml@refs/tags/.*$` |
| `schedule` | n/a | n/a | `--certificate-identity-regexp ^…release.yml@refs/tags/.*$` |
| `workflow_dispatch` (default) | `canonical` | empty | `--certificate-identity-regexp ^…release.yml@refs/tags/.*$` |
| `workflow_dispatch` opt-in | `manual-retry-exception` | `refs/heads/main` (e.g.) | `--certificate-identity …release.yml@refs/heads/main` (literal) + `::notice::` |
| `workflow_dispatch` misuse | `manual-retry-exception` | empty | **fails closed** before cosign runs |
| `workflow_dispatch` misuse | `manual-retry-exception` | wildcard / regex metachar | **fails closed** before cosign runs |

Behavior on automated triggers (`release`, `schedule`) is byte-for-byte unchanged: same regex, same cosign args, same fail-closed posture. The only externally visible change for those triggers is the additional "Resolve cosign verification identity" step in the run log printing `Verification mode: canonical (cosign regex)`.

## Hard-rule compliance

- ❌ Does **NOT** touch tag `v1.2.1` or any other release tag.
- ❌ Does **NOT** modify or republish any release artifact.
- ❌ Does **NOT** modify the v1.2.1 historical evidence record (`docs/runbooks/release-candidate-evidence.md` § "v1.2.1 release evidence record (2026-05-10)" is unchanged in this PR).
- ❌ Does **NOT** modify the launch ledger (`docs/launch-readiness-review-may-8.md` is unchanged in this PR).
- ❌ Does **NOT** modify `release.yml`, `docker-image.yml`, or any other workflow.
- ❌ Does **NOT** modify branch protection.
- ❌ Does **NOT** reopen issue #78.
- ❌ Does **NOT** modify any of the PR #88 packet docs.
- ❌ Does **NOT** introduce any official Clockify/vendor claim.
- ❌ Does **NOT** change paid-hosted/commercial readiness; those follow-ups remain deferred.

## Verifier results (all green)

- `actionlint -color=false .github/workflows/*.yml` → exit 0
- `ruby -ryaml YAML.load_file('.github/workflows/release-smoke.yml')` → OK
- `make doc-parity` → doc-parity / launch-review-ledger / launch-checklist-parity / launch-evidence-gate all OK
- `make launch-checklist-parity` → OK
- `make script-tests` → all 18 suites green
- `git diff --check` → exit 0
- Diff scope: only `.github/workflows/release-smoke.yml` and `docs/verification.md`; nothing else (verified the v1.2.1 evidence record, the launch ledger, and the PR #88 packets all show empty diff).

## Test plan

- [x] actionlint clean
- [x] YAML parses
- [x] All four local verifier suites green
- [x] Diff is workflow + verification.md only (2 files, +217/−19)
- [ ] Reviewer spot-check: shape guard accepts `refs/heads/main` and `refs/tags/v1.2.1`; rejects empty, `*`, `refs/heads/m a in`, `refs/heads/main; rm -rf /`, `master`, `refs/heads/feature/$BAD`
- [ ] Reviewer spot-check: automated triggers always go through the canonical regex regardless of `inputs`
- [ ] Reviewer spot-check: container-image cosign verify is unchanged

## Remaining risks

- A future maintainer who selects `manual-retry-exception` without reading `docs/verification.md` might pass an unexpected `expected_workflow_ref`. Mitigations: (a) the shape guard rejects non-`refs/(heads|tags)/...` values; (b) the run log carries a loud `::notice::` annotation explicitly identifying the exception and its preconditions; (c) the default mode is canonical; (d) cosign's literal `--certificate-identity` will still fail if the given SAN does not match the actual signature, so a wrong `expected_workflow_ref` cannot silently pass.
- The container-image cosign verify (against `docker-image.yml`) is not affected; if a future docker-image.yml retry needs the same treatment it would be a separate follow-up. Out of scope here.

## Related

- v1.2.1 release: https://github.com/apet97/go-clockify/releases/tag/v1.2.1
- PR #94 (`6fe58bd`) — v1.2.1 release evidence + accepted SAN exception (the historical record this PR makes the workflow self-document)
- PR #92 (`2766b39`) — `release.yml` GORELEASER_CURRENT_TAG pin + workflow_dispatch retry path (the upstream fix for the GoReleaser bug that necessitated the SAN exception)