### PR TITLE
polish(public): normalize community release readiness state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,17 @@
 A production-grade [Model Context Protocol](https://modelcontextprotocol.io)
 server for [Clockify](https://clockify.me), written in Go. Three
 transports (stdio, streamable HTTP 2025-03-26, opt-in gRPC behind
-`-tags=grpc`), five policy modes, signed releases. v1.2.0 is the
-current stable line. The active workstream is the Clockify
-launch-candidate evidence pass; any official-product promotion remains
-gated on the external evidence and legal/product approval below.
+`-tags=grpc`), five policy modes, signed releases. **`v1.2.1` is the
+current stable community/self-hosted line** (released 2026-05-10 from
+rc.3 peeled commit `ce56414`; see
+[`docs/runbooks/release-candidate-evidence.md`](docs/runbooks/release-candidate-evidence.md)
+§ "v1.2.1 release evidence record (2026-05-10)" for the canonical
+evidence anchor). The repository is unofficial and **not affiliated
+with or endorsed by Clockify**; any paid-hosted / commercial /
+"official Clockify" promotion remains explicitly deferred — see the
+external evidence and legal/product gates summarised below and the
+"Deferred paid-hosted/commercial follow-ups" section of
+[`docs/launch-readiness-review-may-8.md`](docs/launch-readiness-review-may-8.md).
 
 ## Read first (in this order)
 

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ script-tests:
 	bash scripts/test-prepare-rc-evidence.sh
 	bash scripts/test-publish-npm.sh
 	bash scripts/test-claude-campaign.sh
+	bash scripts/test-release-workflow-structure.sh
 
 claude-campaign-plan:
 	bash scripts/claude-campaign.sh --dry-run

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # clockify-mcp-go
 
 > A [Model Context Protocol][mcp] server for [Clockify][clockify] — plug any MCP client into your time-tracking workspace and let it log time, run reports, and manage projects on your behalf.
+>
+> **Unofficial community project. Not affiliated with or endorsed by Clockify.** Single-maintainer, public source under MIT, see [SUPPORT.md](SUPPORT.md) and [GOVERNANCE.md](GOVERNANCE.md) for adoption posture.
 
 [![Go version](https://img.shields.io/badge/go-1.25-00ADD8?logo=go)](go.mod)
 [![Release](https://img.shields.io/github/v/release/apet97/go-clockify?color=7e57c2)](https://github.com/apet97/go-clockify/releases)
@@ -56,18 +58,28 @@ npx @apet97/clockify-mcp-go
 # https://github.com/apet97/go-clockify/releases
 ```
 
-Private/internal installs: while this repository is private, configure
-Go to bypass the public module proxy for this module and make sure your
-GitHub credentials can read the repo before running `go install`:
-`go env -w GOPRIVATE=github.com/apet97/go-clockify`. SSH auth, GitHub
-CLI auth, or an HTTPS credential/PAT with repo access are all valid.
-GitHub Releases and Issues also require access to the private repository.
-
 Verify:
 
 ```sh
 clockify-mcp --version
 ```
+
+### Current release status
+
+`v1.2.1` is the current stable community/self-hosted line, cut from the
+rc.3 peeled commit and released on 2026-05-10
+([GitHub Release](https://github.com/apet97/go-clockify/releases/tag/v1.2.1) ·
+46 signed assets · npm `@apet97/clockify-mcp-go` `dist-tags.latest=1.2.1`
+· container image `ghcr.io/apet97/go-clockify:1.2.1`). Operators
+verifying signatures should follow [docs/verification.md](docs/verification.md);
+paid-hosted / commercial / "official Clockify" framing is explicitly
+out of scope per [docs/launch-readiness-review-may-8.md](docs/launch-readiness-review-may-8.md)
+§ "Deferred paid-hosted/commercial follow-ups …".
+
+If your environment routes Go module fetches through a custom proxy or
+VCS resolver and you want to skip the public proxy for this module,
+`go env -w GOPRIVATE=github.com/apet97/go-clockify` is supported but
+not required for a standard `go install` against the public repo.
 
 Get a Clockify API key from [Profile → Advanced](https://app.clockify.me/user/preferences) and export it:
 
@@ -452,8 +464,8 @@ is retained as the historical post-PR #51 handoff.
 - Adoption expectations, response-time posture, `v1.x` wire-format stability guarantee: [SUPPORT.md](SUPPORT.md)
 - Governance (single-maintainer, merge gate, sensitive-area self-review): [GOVERNANCE.md](GOVERNANCE.md)
 - Security vulnerabilities: [SECURITY.md](SECURITY.md) (private disclosure channel)
-- Bug reports and feature requests: [GitHub Issues](https://github.com/apet97/go-clockify/issues) (requires repo access while private)
-- Release history: [CHANGELOG.md](CHANGELOG.md) · [GitHub Releases](https://github.com/apet97/go-clockify/releases) (requires repo access while private)
+- Bug reports and feature requests: [GitHub Issues](https://github.com/apet97/go-clockify/issues)
+- Release history: [CHANGELOG.md](CHANGELOG.md) · [GitHub Releases](https://github.com/apet97/go-clockify/releases)
 - Versioning, support window, breaking-change policy: [docs/release-policy.md](docs/release-policy.md)
 - Documentation map: [docs/README.md](docs/README.md)
 

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -86,9 +86,11 @@ curl -fsS -H "Authorization: Bearer $MCP_BEARER_TOKEN" \
 The manifest references `ghcr.io/apet97/go-clockify:latest`. The project's
 Dockerfile lives in [`deploy/Dockerfile`](../Dockerfile). In production:
 
-- Pin to a released tag (for example `ghcr.io/apet97/go-clockify:v1.2.0`)
-  instead of `:latest` so rollouts are deterministic. See
-  [`SUPPORT.md`](../../SUPPORT.md) for the current supported line.
+- Pin to a released tag (for example `ghcr.io/apet97/go-clockify:1.2.1`)
+  instead of `:latest` so rollouts are deterministic. The image tag is
+  bare semver (no `v` prefix) — the goreleaser metadata-action emits
+  `pattern={{version}}` so the published tag is `1.2.1`, not `v1.2.1`.
+  See [`SUPPORT.md`](../../SUPPORT.md) for the current supported line.
 - Consider building your own image from a verified release binary and
   publishing it to your internal registry.
 - Mirror the image to keep supply-chain provenance under your control.

--- a/deploy/k8s/base/deployment.yaml
+++ b/deploy/k8s/base/deployment.yaml
@@ -36,7 +36,9 @@ spec:
       containers:
         - name: clockify-mcp
           # Pin to an immutable tag. Bump on release; never use :latest in production.
-          image: ghcr.io/apet97/go-clockify:v1.2.0
+          # Tag is bare semver (no `v` prefix) — goreleaser metadata-action emits
+          # pattern={{version}}, so the published tag is `1.2.1`, not `v1.2.1`.
+          image: ghcr.io/apet97/go-clockify:1.2.1
           imagePullPolicy: IfNotPresent
           args: []
           env:

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -111,9 +111,20 @@ work and commit it.
     § "Final integration audit — rc.3 cycle ledger" for the
     consolidated rc.3 cycle PR ledger (#74, #75, #76, #77, #80,
     #83, #84, #85), validator-quirk classifications, and
-    next-step actions on the still-open gates. The repository is
-    not launch-ready and the final `v1.2.1` tag is post-Lane-6
-    and requires operator action.
+    next-step actions on the still-open gates. **`v1.2.1` is the
+    current stable community/self-hosted line**, cut from rc.3's
+    peeled commit `ce56414` and released 2026-05-10 (see
+    [`runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+    § "v1.2.1 release evidence record (2026-05-10)" for the
+    canonical evidence anchor — including the bounded
+    release-smoke SAN exception and the
+    `ghcr.io/apet97/go-clockify:1.2.1` container image identity).
+    Paid-hosted / commercial / "official Clockify" follow-ups
+    remain explicitly deferred per
+    [`launch-readiness-review-may-8.md`](launch-readiness-review-may-8.md)
+    § "Deferred paid-hosted/commercial follow-ups — not required
+    for community/self-hosted v1.2.1" and must not be re-promoted
+    into community/self-hosted blockers.
 
 If a local-shell run of the live-contract suite reports `ok`
 suspiciously fast (≤ ~0.5s), the env-var gate

--- a/docs/launch-candidate-checklist.md
+++ b/docs/launch-candidate-checklist.md
@@ -490,22 +490,32 @@ checked.
 
 - [ ] `make release-check` green from a clean checkout on at
       least one Linux x64 and one macOS arm64 host.
+      _Closed 2026-05-10 for community/self-hosted v1.2.1 by PR #91
+      merge `5206477`: macOS arm64 leg from the rc.3
+      `opus/group7-release-rc3-20260510` worktree, Linux x64 leg from
+      a Lane B Docker `linux/amd64` `golang:1.25-bookworm` clean-clone
+      run (2026-05-10T17:05:40Z–17:21:48Z, exit 0,
+      `release-check: OK — local pre-ship gate passed`). Full evidence
+      record in
+      [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+      § "Linux x64 release-check evidence — v1.2.1-rc.3"._
 - [ ] All required workflows on `main` green: `ci.yml`,
       `build-matrix.yml`, `live-contract.yml` (latest scheduled
       run), `release-smoke.yml` (latest tag), `link-check.yml`,
       `chaos.yml`, `mutation.yml`, `reproducibility.yml`,
       `bench.yml`. No skipped-but-required steps.
-      _Tracking 2026-05-09: `make launch-external-status` reports the
-      latest `mutation.yml` scheduled run 25592823559 is
-      `completed/cancelled` on pushed commit
-      4fe957547f9e6aea749a85f87823d17a0ccc2928. `gh run view` shows
-      the `internal/tools` matrix leg was cancelled while the other
-      mutation legs succeeded. The `internal/tools` matrix-leg timeout
-      increase landed on `main` in `2e7b6bd` ("May 9 hardening")
-      ahead of `308c815` and the later docs-only commits, so the
-      workflow fix is on the default branch; the next scheduled
-      `mutation.yml` cron after that landing still needs to record a
-      green run on the final candidate SHA before this box can close._
+      _Closed 2026-05-10 for community/self-hosted v1.2.1 by PR #89
+      merge `637157d`: scheduled `mutation.yml` cron run
+      [25620978280](https://github.com/apet97/go-clockify/actions/runs/25620978280)
+      went green across all 6 matrix legs on `ab2a51e`; PR #87 + PR
+      #88 added no `internal/*` Go source so the green cron is
+      byte-for-byte equivalent-source mutation evidence for both rc.3
+      (`ce56414`) and current main. The literal final-candidate-SHA
+      cadence-wait remains a paid-hosted/commercial follow-up
+      tracked under
+      [`docs/launch-readiness-review-may-8.md`](launch-readiness-review-may-8.md)
+      § "Deferred paid-hosted/commercial follow-ups — not required
+      for community/self-hosted v1.2.1"._
 - [x] `make verify-bench` and `make bench-baseline-check` green;
       no regression > the documented threshold versus the
       baseline.

--- a/docs/launch-readiness-review-may-8.md
+++ b/docs/launch-readiness-review-may-8.md
@@ -6,21 +6,22 @@ replacement for `docs/launch-candidate-checklist.md`.
 
 ## ⚠️ Open risk callouts
 
-- **Branch-protection posture is the 2026-05-09 cleanup posture, not
-  the final hardening posture.** Classic protection on `main` is
-  currently restored with only the three D9 launch required-status
-  checks (`Doctor strict smoke`, `Doctor Postgres backend`,
-  `Shared-service Postgres E2E`). This recovers from a prior
-  `Branch not protected` state observed during the 2026-05-09 repo-state
-  cleanup pass and is **not** equivalent to the historical 19 PR-required
-  context profile documented in
-  [`docs/branch-protection.md`](branch-protection.md). Restoring the
-  remaining 16 contexts (the full PR-required list is enumerated in
-  the "Required status checks" section of
-  [`docs/branch-protection.md`](branch-protection.md)) is preserved as an
-  explicit maintainer follow-up. **Do not treat the 3-of-19 posture as
-  equivalent to the documented hardening profile, and do not change
-  branch protection again without explicit operator approval.**
+- **Branch-protection posture: 21-context restoration landed
+  2026-05-10; do not change without operator approval.** Classic
+  protection on `main` was re-applied 2026-05-09 with the three D9
+  launch required-status checks (`Doctor strict smoke`, `Doctor
+  Postgres backend`, `Shared-service Postgres E2E`) after a prior
+  `Branch not protected` state was observed during the 2026-05-09
+  repo-state cleanup pass. On 2026-05-10 the historical 18-context
+  PR-required list (per
+  [`docs/branch-protection.md`](branch-protection.md) § "Required
+  status checks") was added back via additive PUT against
+  `repos/apet97/go-clockify/branches/main/protection`, bringing the
+  live enforcement to **21 required contexts** (historical 18 + the
+  three D9 launch checks). Issue #78 closed as part of that
+  restoration; `scripts/audit-branch-protection.sh` confirms the live
+  state matches the documented snapshot. **Do not change branch
+  protection without explicit operator approval.**
 
 ## Closed in this remediation pass
 

--- a/docs/official-clockify-mcp-gap-analysis.md
+++ b/docs/official-clockify-mcp-gap-analysis.md
@@ -293,8 +293,26 @@ What is missing for tier 3 is intentionally narrow:
 In priority order — closing the lower-numbered ones first
 unblocks the next.
 
+> **Scope note (2026-05-10).** The blockers in this section gate the
+> hypothetical **Clockify-supported / paid-hosted / "official Clockify"**
+> launch path only. The community/self-hosted track is closed at
+> `v1.2.1` (released 2026-05-10 from rc.3 peeled commit `ce56414`; see
+> [`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+> § "v1.2.1 release evidence record (2026-05-10)" for the canonical
+> evidence anchor). The Tier-3 / "Clockify-supported product launch"
+> blockers itemised below are the same five paid-hosted / commercial
+> follow-ups deferred per
+> [`docs/launch-readiness-review-may-8.md`](launch-readiness-review-may-8.md)
+> § "Deferred paid-hosted/commercial follow-ups — not required for
+> community/self-hosted v1.2.1": paid-hosted external security review,
+> DPA / terms / privacy posture, trademark / "official Clockify"
+> language plus `clockify://` URI / gRPC service-name branding,
+> P1-8 paid-commercial RLS decision, and cross-replica hosted HTTP
+> quotas. They do **not** block the community/self-hosted release.
+
 The remaining blockers are not local test failures. They are still
-launch blockers: Group 6 candidate-tag security walk-through evidence,
+launch blockers for the paid-hosted / commercial / "official
+Clockify" track: Group 6 candidate-tag security walk-through evidence,
 Group 7 release/sigstore/SLSA evidence, pushed workflow first-run
 evidence where still missing, repository-state cleanup,
 public-readiness disposition, hosted/platform evidence, and
@@ -303,9 +321,11 @@ Local checks are useful but not sufficient for a Clockify-supported
 product launch claim. Group 1 scheduled live-contract cron greens are
 now archived on `feef83c641ced93d2ab6ba07ef766d61c82cc703`; the PR #59
 through PR #62 manual live-probe work remains coverage evidence only.
-Rechecked on 2026-05-09: the repository description and issue #28
-remain stale/open, and candidate-tag security plus release evidence are
-still missing.
+Group 6/7 candidate-tag evidence + repository description + issue #28
+all closed during the rc.3 cycle (PRs #84, #85, #77, #88) and the
+v1.2.1 final release on 2026-05-10; the items still outstanding
+are the five paid-hosted/commercial gates listed in the scope note
+above.
 
 1. ~~**Scheduled live-contract cron evidence.**~~ **Closed 2026-05-09.**
    *Where:* `.github/workflows/live-contract.yml` and the rolling

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -56,14 +56,36 @@ The manual live-campaign baseline remains
 post-PR #51 local readiness gates, PR #59's manual
 sacrificial-workspace MCP-path probes, PR #62's invite-user validation
 probe, and later live-test hooks or local coverage for the current
-128-tool catalog. The remaining
-blockers are not local test failures, but they are still launch
-blockers: Group 6 candidate-tag security evidence, Group 7
-release/sigstore/SLSA evidence, repository-state cleanup,
-public-readiness disposition, and legal/product approval for any
-official-product claim. Local `release-check`, PR CI greens, and manual
-exhaustive live probes are necessary context but not sufficient for an
-official/product launch-ready claim.
+128-tool catalog. The community/self-hosted track is closed at
+**`v1.2.1`** (released 2026-05-10 from rc.3 peeled commit `ce56414`;
+46 signed assets, npm `dist-tags.latest=1.2.1`, container image
+`ghcr.io/apet97/go-clockify:1.2.1`, Reproducibility 9-leg matrix
+green, Deploy chain end-to-end green; full evidence in
+[`docs/runbooks/release-candidate-evidence.md`](runbooks/release-candidate-evidence.md)
+§ "v1.2.1 release evidence record (2026-05-10)").
+
+For any paid-hosted / commercial / "official Clockify" launch claim,
+the remaining blockers are not local test failures: Group 6
+candidate-tag security evidence and Group 7 release/sigstore/SLSA
+evidence are closed for the v1.2.1 cycle (see the evidence record
+above), but a Clockify-supported / official-product launch additionally
+requires repository-state cleanup beyond what community/self-hosted
+needs, pushed workflow first-run evidence on the relevant pushed
+SHAs, the public-readiness disposition, and legal/product approval —
+none of which the community/self-hosted release decides. Local
+`release-check`, PR CI greens, and manual exhaustive live probes are
+necessary context but **not sufficient** for an
+official/product launch-ready claim. The five paid-hosted gates that block such a
+claim are explicitly **deferred** per
+[`docs/launch-readiness-review-may-8.md`](launch-readiness-review-may-8.md)
+§ "Deferred paid-hosted/commercial follow-ups — not required for
+community/self-hosted v1.2.1": paid-hosted external security review,
+DPA / terms / privacy posture, trademark / "official Clockify"
+language plus `clockify://` URI / gRPC service-name branding review,
+P1-8 paid-commercial RLS decision, and cross-replica hosted HTTP
+quotas. They do not block the community/self-hosted v1.2.1 release;
+they are necessary inputs only for a future paid-hosted /
+official-product launch.
 pushed workflow evidence for CI, CodeQL, Dependency Review, Semgrep,
 Build matrix, Docker Image, and Link check is now green on `308c815`;
 future workflow drift still belongs in the evidence set, not in local
@@ -93,7 +115,7 @@ reviewer summary). Auth-failure triage lives in
 |--------------------|-------------------------------------------------------------------------------------------|------------------------------------------------------|
 | Kustomize          | Reference manifests with base + dev/prod overlays, NetworkPolicy, PDB, ServiceMonitor, PrometheusRule with burn-rate alerts. | [`deploy/k8s/`](../deploy/k8s/) and [`deploy/k8s/README.md`](../deploy/k8s/README.md) |
 | Helm               | Same surface as Kustomize, packaged as a chart for clusters that prefer Helm.            | [`deploy/helm/`](../deploy/helm/) and `deploy/helm/README.md` |
-| Container image    | Multi-arch, distroless, non-root, read-only root FS, dropped capabilities, Trivy-scanned, cosign-signed. | `ghcr.io/apet97/go-clockify:v1.2.0` (see [`docs/verification.md`](verification.md); [`SUPPORT.md`](../SUPPORT.md) names the current supported line) |
+| Container image    | Multi-arch, distroless, non-root, read-only root FS, dropped capabilities, Trivy-scanned, cosign-signed. | `ghcr.io/apet97/go-clockify:1.2.1` (see [`docs/verification.md`](verification.md); [`SUPPORT.md`](../SUPPORT.md) names the current supported line) |
 | Raw binary         | Single static binary, no runtime dependencies. Suitable for systemd or container-less hosts. | `go install github.com/apet97/go-clockify/cmd/clockify-mcp@latest` or download from the Releases page. |
 
 Image tags are not pinned in the `prod` Kustomize overlay by design —

--- a/docs/runbooks/image-digest-pinning.md
+++ b/docs/runbooks/image-digest-pinning.md
@@ -24,7 +24,7 @@ At the moment of deploy, take one of two paths:
 
 ```sh
 # 1. Resolve the digest for the tag you want to ship.
-docker buildx imagetools inspect ghcr.io/apet97/go-clockify:v1.2.0 \
+docker buildx imagetools inspect ghcr.io/apet97/go-clockify:1.2.1 \
   --format '{{json .Manifest.Digest}}'
 # -> "sha256:abc123…"
 
@@ -58,7 +58,7 @@ spec:
   source:
     kustomize:
       images:
-        - ghcr.io/apet97/go-clockify:v1.2.0
+        - ghcr.io/apet97/go-clockify:1.2.1
 ```
 
 Flux example:

--- a/scripts/check-doc-parity.sh
+++ b/scripts/check-doc-parity.sh
@@ -200,6 +200,13 @@ banned_strings=(
   "every binary and container image ships with cosign signatures, SPDX SBOM, and SLSA build provenance"
   "attested with SLSA build provenance, and scanned with"
   "A SLSA build-provenance attestation stored in the GitHub"
+  # The repository is public on GitHub. Pre-flip wording about the
+  # private-repo install path / private Releases / private Issues is
+  # now factually wrong on every public surface. Banned to prevent
+  # regression. (See README.md commit history for the public release
+  # state pin.)
+  "while this repository is private"
+  "(requires repo access while private)"
 )
 
 banned_scan_files=("${DOC_DIRS[@]}" "${DOC_FILES_TOP[@]}" AGENTS.md .github/workflows/docker-image.yml .github/workflows/release.yml)
@@ -225,6 +232,18 @@ if [ -n "$multiline_brand_claim_hits" ]; then
   while IFS= read -r line; do
     err "banned premature official-product claim found: $line"
   done <<< "$multiline_brand_claim_hits"
+fi
+
+# Banned shape: ghcr.io image tags must be bare semver, not v-prefixed.
+# The goreleaser metadata-action emits `pattern={{version}}` so the
+# published container tag is `1.2.1`, not `v1.2.1`. release-smoke.yml
+# strips the `v` with `image_tag="${TAG#v}"`. Examples that show
+# `:v1.2.1` are dead documentation that breaks operator copy-paste.
+ghcr_v_prefix_hits=$(grep -rnE 'ghcr\.io/[^[:space:]]*:v[0-9]' "${banned_scan_files[@]}" 2>/dev/null || true)
+if [ -n "$ghcr_v_prefix_hits" ]; then
+  while IFS= read -r line; do
+    err "banned v-prefixed ghcr.io image tag (use bare semver, e.g. ghcr.io/apet97/go-clockify:1.2.1): $line"
+  done <<< "$ghcr_v_prefix_hits"
 fi
 
 if [ ! -f README.md ]; then

--- a/scripts/check-launch-review-ledger.sh
+++ b/scripts/check-launch-review-ledger.sh
@@ -392,6 +392,33 @@ for pattern in "${required_public_content_patterns[@]}"; do
   fi
 done
 
+# Deferred paid-hosted/commercial section header pin.
+#
+# The ledger's "## Deferred paid-hosted/commercial follow-ups — not
+# required for community/self-hosted v1.2.1" section is the canonical
+# scope-correction anchor: it lists the five paid-hosted gates that
+# moved out of the community/self-hosted blocker list (per PR #90) and
+# carries their full owner / evidence / non-goal disposition. Without
+# this section header in the ledger, the deferral can drift back to
+# "active blocker" wording elsewhere in the ledger and start
+# re-blocking community/self-hosted releases.
+#
+# NOTE: the literal source file uses an em-dash (U+2014); we grep
+# against `$normalized`, which `perl -CSDA -pe 's/[\x{2010}…\x{2014}]/-/g'`
+# folded into ASCII hyphen-minus. The pinned strings here MUST be the
+# ASCII-normalized form, not the source spelling.
+required_deferred_paid_hosted_section_patterns=(
+  "## Deferred paid-hosted/commercial follow-ups - not required for community/self-hosted v1.2.1"
+  "These are not release gates for community/self-hosted v1.2.1."
+  "They become gates only for a paid-hosted/commercial launch."
+)
+
+for pattern in "${required_deferred_paid_hosted_section_patterns[@]}"; do
+  if ! grep -qF "$pattern" "$normalized"; then
+    err "deferred paid-hosted/commercial section missing required text: $pattern"
+  fi
+done
+
 if [ "$fail" != "0" ]; then
   echo "launch-review-ledger: FAIL" >&2
   exit 1

--- a/scripts/test-check-doc-parity.sh
+++ b/scripts/test-check-doc-parity.sh
@@ -1474,6 +1474,47 @@ MUTATOR=mut_docker_image_slsa_notice_missing
 run_case "Phase 7: docker-image SLSA feature-gate notice missing fails closed" \
     1 '\.github/workflows/docker-image\.yml must qualify image SLSA provenance availability'
 
+# --- Case 71: stale "while this repository is private" wording in README ---
+# The repo is public on GitHub. Pre-flip wording in user-onboarding
+# docs is now factually wrong; the banned-string guard must catch it.
+mut_stale_private_repo_install() {
+    printf '\nPrivate/internal installs: while this repository is private, configure GOPRIVATE.\n' \
+        >> "$1/README.md"
+}
+MUTATOR=mut_stale_private_repo_install
+run_case "Phase 3: stale 'while this repository is private' README wording fails closed" \
+    1 "banned stale public-surface string"
+
+# --- Case 72: stale "(requires repo access while private)" parenthetical ---
+mut_stale_requires_private_access() {
+    printf '\nReleases (requires repo access while private)\n' \
+        >> "$1/README.md"
+}
+MUTATOR=mut_stale_requires_private_access
+run_case "Phase 3: stale '(requires repo access while private)' parenthetical fails closed" \
+    1 "banned stale public-surface string"
+
+# --- Case 73: ghcr image tag uses v-prefix in user-onboarding doc ---
+# Released container tag is bare semver per goreleaser's
+# `pattern={{version}}` metadata-action; `:v1.2.1` would break
+# operator copy-paste.
+mut_ghcr_v_prefix_in_doc() {
+    printf '\nPin to ghcr.io/apet97/go-clockify:v1.2.1 in production.\n' \
+        >> "$1/docs/production-readiness.md"
+}
+MUTATOR=mut_ghcr_v_prefix_in_doc
+run_case "Phase 3: v-prefixed ghcr.io image tag fails closed" \
+    1 'banned v-prefixed ghcr\.io image tag'
+
+# --- Case 74: bare semver ghcr image tag is allowed (negative case) ---
+mut_ghcr_bare_semver_in_doc() {
+    printf '\nPin to ghcr.io/apet97/go-clockify:1.2.1 in production.\n' \
+        >> "$1/docs/production-readiness.md"
+}
+MUTATOR=mut_ghcr_bare_semver_in_doc
+run_case "Phase 3: bare semver ghcr.io image tag passes" \
+    0 'doc-parity: OK'
+
 # --- Final report ---
 echo
 if [ "$tests_failed" -gt 0 ]; then

--- a/scripts/test-check-launch-evidence-gate.sh
+++ b/scripts/test-check-launch-evidence-gate.sh
@@ -111,12 +111,34 @@ else
 fi
 
 # ── Test 7: Group 7 box checked without evidence => FAIL ────────────
+#
+# After the post-v1.2.1 closure-annotation pass, the real Group 7
+# "All required workflows on `main` green" row in
+# launch-candidate-checklist.md carries an inline `_Closed
+# YYYY-MM-DD …_` annotation (the row stays unchecked per the
+# operator's "do not tick" rule, but it has the proper evidence
+# annotation alongside). The historical `[ ]` -> `[x]` substitution
+# against the real checklist no longer reproduces the
+# "checked-without-evidence" anti-pattern because the gate sees the
+# annotation and passes. Construct a minimal synthetic checklist
+# instead — a checked Group 7 box with no evidence URL or `_Closed_`
+# annotation within 8 lines — so the negative test's invariant
+# ("checked Group 7 box without evidence must fail the gate") stays
+# load-bearing regardless of the real checklist's state. Mirrors the
+# Test 8 / Test 9 synthetic-fixture pattern.
 
 echo "== Test 7: Group 7 box checked without evidence => FAIL"
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
-sed 's/^- \[ \] All required workflows on .main. green: .ci.yml./- [x] All required workflows on .main. green: .ci.yml./' \
-  "$real_checklist" > "$tmp"
+cat > "$tmp" <<'EOF'
+# Launch candidate checklist — synthetic fixture for evidence-gate test 7
+
+## 7. CI / release readiness
+
+- [x] All required workflows on `main` green: `ci.yml`, `codeql.yml`,
+      `dependency-review.yml`, `mutation.yml`, `reproducibility.yml`.
+- [ ] Other gates not exercised by this test.
+EOF
 if LAUNCH_CHECKLIST="$tmp" bash "$script" >/dev/null 2>&1; then
   fail "Group 7 checked box without evidence should fail but exited 0"
 else

--- a/scripts/test-check-launch-review-ledger.sh
+++ b/scripts/test-check-launch-review-ledger.sh
@@ -179,6 +179,15 @@ EOF
   Public visibility still depends on the external, repository-state,
   and legal/product gates above.
 
+## Deferred paid-hosted/commercial follow-ups — not required for community/self-hosted v1.2.1
+
+These are not release gates for community/self-hosted v1.2.1.
+They become gates only for a paid-hosted/commercial launch.
+They must not block final v1.2.1 if the release notes and public docs
+keep the project framed as community/self-hosted and do not claim
+official Clockify status.
+The PR #88 packet files remain future request templates only.
+
 ## Deferred low-risk follow-ups
 
 - Deferred section stays part of the checked disposition body.
@@ -488,6 +497,25 @@ mut_missing_public_local_scope() {
 }
 MUTATOR=mut_missing_public_local_scope
 run_case "missing public-content local scope fails closed" 1 'public-content audit disposition missing required text.*Local artifact/full-tree review'
+
+# --- Deferred paid-hosted/commercial section header guard ---
+# The ledger must keep the canonical "## Deferred paid-hosted/
+# commercial follow-ups — not required for community/self-hosted
+# v1.2.1" section header (PR #90 scope correction) so the deferral
+# cannot silently drift back to "active blocker" wording.
+mut_missing_deferred_section_header() {
+  perl -0pi -e 's/^## Deferred paid-hosted\/commercial follow-ups — not required for community\/self-hosted v1\.2\.1\n//m' "$1"
+}
+MUTATOR=mut_missing_deferred_section_header
+run_case "missing deferred paid-hosted section header fails closed" \
+  1 'deferred paid-hosted/commercial section missing required text.*Deferred paid-hosted'
+
+mut_missing_deferred_intro_sentence() {
+  perl -0pi -e 's/These are not release gates for community\/self-hosted v1\.2\.1\.\n//' "$1"
+}
+MUTATOR=mut_missing_deferred_intro_sentence
+run_case "missing deferred paid-hosted intro sentence fails closed" \
+  1 'deferred paid-hosted/commercial section missing required text.*not release gates for community/self-hosted'
 
 if [ "$tests_failed" -ne 0 ]; then
   printf 'check-launch-review-ledger tests: %d/%d FAILED\n' "$tests_failed" "$tests_run" >&2

--- a/scripts/test-release-workflow-structure.sh
+++ b/scripts/test-release-workflow-structure.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# test-release-workflow-structure.sh — pin the post-v1.2.1 release
+# infrastructure so future workflow refactors cannot silently drop:
+#
+#   1. PR #92's GoReleaser tag-pinning fix in `.github/workflows/release.yml`.
+#      Without GORELEASER_CURRENT_TAG, goreleaser can resolve the wrong
+#      tag when a final release peels to the same commit as its rc
+#      (the v1.2.1 retry incident), upload to the wrong release, and
+#      fail with 422 already_exists.
+#
+#   2. PR #95's two-mode cosign verification in
+#      `.github/workflows/release-smoke.yml`. The canonical mode pins
+#      `release.yml@refs/tags/.*`; the manual-retry-exception mode is
+#      a workflow_dispatch-only opt-in with a literal SAN. Both must
+#      survive future edits.
+#
+#   3. The bounded-marker wording around the v1.2.1 release-smoke SAN
+#      exception in `docs/runbooks/release-candidate-evidence.md` and
+#      `docs/verification.md`. The exception is bounded to v1.2.1 only
+#      and future releases must revert to canonical regex; if those
+#      bounded markers ever get removed, the exception silently
+#      generalises into precedent. The guard fails closed.
+#
+# This script is a pure assertion script — no harness, no fixtures.
+# It checks real files in the repo. Wired into `make script-tests`.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+release_yml="$repo_root/.github/workflows/release.yml"
+release_smoke_yml="$repo_root/.github/workflows/release-smoke.yml"
+evidence_md="$repo_root/docs/runbooks/release-candidate-evidence.md"
+verification_md="$repo_root/docs/verification.md"
+
+fail=0
+
+err() {
+  printf 'ERROR: %s\n' "$1" >&2
+  fail=1
+}
+
+# Asserts a literal fixed-string is present in $2 (file path) and prints
+# a uniform OK / ERROR line.
+require_fixed() {
+  local label="$1"
+  local file="$2"
+  local needle="$3"
+  if [ ! -f "$file" ]; then
+    err "${label}: ${file} not found"
+    return
+  fi
+  if grep -qF -- "$needle" "$file"; then
+    printf 'OK: %s\n' "$label"
+  else
+    err "${label}: missing required marker in ${file}: ${needle}"
+  fi
+}
+
+# Asserts an extended-regex pattern matches in $2 (file path).
+require_regex() {
+  local label="$1"
+  local file="$2"
+  local pattern="$3"
+  if [ ! -f "$file" ]; then
+    err "${label}: ${file} not found"
+    return
+  fi
+  if grep -qE -- "$pattern" "$file"; then
+    printf 'OK: %s\n' "$label"
+  else
+    err "${label}: missing required pattern in ${file}: ${pattern}"
+  fi
+}
+
+# 1. release.yml — PR #92 GORELEASER_CURRENT_TAG pin contract.
+require_fixed "release.yml carries id: resolve-release-tag" \
+  "$release_yml" \
+  "id: resolve-release-tag"
+require_fixed "release.yml pins GORELEASER_CURRENT_TAG to resolved tag" \
+  "$release_yml" \
+  "GORELEASER_CURRENT_TAG: \${{ steps.resolve-release-tag.outputs.release_tag }}"
+require_fixed "release.yml pins v1.2.1 peeled commit guard" \
+  "$release_yml" \
+  "ce56414ae012c4a49d21ae0a319b178619c5966a"
+
+# 2. release-smoke.yml — PR #95 two-mode cosign verification contract.
+require_fixed "release-smoke.yml exposes verification_mode input" \
+  "$release_smoke_yml" \
+  "verification_mode:"
+require_fixed "release-smoke.yml lists canonical option" \
+  "$release_smoke_yml" \
+  "- canonical"
+require_fixed "release-smoke.yml lists manual-retry-exception option" \
+  "$release_smoke_yml" \
+  "- manual-retry-exception"
+require_fixed "release-smoke.yml exposes expected_workflow_ref input" \
+  "$release_smoke_yml" \
+  "expected_workflow_ref:"
+require_fixed "release-smoke.yml resolve step writes IDENT_MODE/value outputs" \
+  "$release_smoke_yml" \
+  "id: ident"
+require_regex "release-smoke.yml branches verify-blob on IDENT_MODE regex/literal" \
+  "$release_smoke_yml" \
+  'case "\$IDENT_MODE" in'
+require_fixed "release-smoke.yml emits loud manual-retry exception notice" \
+  "$release_smoke_yml" \
+  "::notice title=Manual-retry SAN exception in effect::"
+require_fixed "release-smoke.yml strips v-prefix on container image tag" \
+  "$release_smoke_yml" \
+  "image_tag=\"\${TAG#v}\""
+
+# 3. v1.2.1 SAN-exception bounded markers — must stay tightly bounded
+#    so the exception does not generalise into precedent.
+require_fixed "release-candidate-evidence.md contains bounded-to-v1.2.1 marker" \
+  "$evidence_md" \
+  "Accepted exception for v1.2.1 only"
+require_fixed "release-candidate-evidence.md contains revert-to-canonical marker" \
+  "$evidence_md" \
+  "Future releases that follow a clean tag-push path will revert to the canonical"
+require_fixed "verification.md documents two cosign-verify modes" \
+  "$verification_md" \
+  "## Two cosign-verify modes (canonical vs manual-retry exception)"
+
+if [ "$fail" -ne 0 ]; then
+  printf 'release-workflow-structure tests: FAIL\n' >&2
+  exit 1
+fi
+
+printf 'release-workflow-structure tests: OK\n'


### PR DESCRIPTION
> 🟢 **Post-v1.2.1 public-readiness polish, doc + verifier only.** Does not touch tags, release artefacts, the v1.2.1 historical evidence record, branch protection, issue #78, or the deferred paid-hosted/commercial packet docs. Does not weaken any security, auth, audit, release, or evidence gate. Does not claim official Clockify status.

## Why

`v1.2.1` is the current stable **community/self-hosted** line (released 2026-05-10 from rc.3 peeled commit `ce56414`), but several public-facing docs still reflected pre-release / private-repo state:

- README claimed the repo was private and that GitHub Releases / Issues required private access.
- AGENTS.md pinned `v1.2.0 is the current stable line`.
- `docs/agent-handoff.md` said `the repository is not launch-ready and the final v1.2.1 tag is post-Lane-6 and requires operator action`.
- `docs/production-readiness.md` listed Group 6/7 as "still launch blockers" and used `ghcr.io/apet97/go-clockify:v1.2.0` as the example.
- `docs/launch-readiness-review-may-8.md` opened with an "Open risk callouts" claim that branch protection was in 3-of-19 posture and that 16 contexts were pending — Issue #78 closed and 21 contexts went live on 2026-05-10.
- `docs/launch-candidate-checklist.md` Group 7 boxes for closed evidence lacked the `_Closed YYYY-MM-DD by …_` annotation used everywhere else.
- A handful of `ghcr.io/<…>:v1.2.0` examples used the wrong v-prefix (the released image tag is bare semver — `release-smoke.yml` strips the `v` with `image_tag="${TAG#v}"`).

There was also no regression guard preventing these classes of drift from sneaking back, and no test asserted that PR #92's `GORELEASER_CURRENT_TAG` pin and PR #95's release-smoke two-mode verification survive future refactors.

## What changed

### Documentation fixes (11 files)

| File | Change |
|---|---|
| `README.md` | Drop "while this repository is private" install paragraph and "(requires repo access while private)" parentheticals. Add "Unofficial community project. Not affiliated with or endorsed by Clockify." disclaimer in the intro. Add a "Current release status" subsection pinning v1.2.1 with release/npm/image links. |
| `AGENTS.md` | Bump version pin from v1.2.0 → v1.2.1 with a pointer to the canonical evidence record; tighten the "official-product promotion remains gated" wording to explicitly name the paid-hosted/commercial track. |
| `docs/agent-handoff.md` | Drop "not launch-ready"; record v1.2.1 as the current community/self-hosted line and the paid-hosted follow-ups as deferred. |
| `docs/production-readiness.md` | Reframe so community/self-hosted is closed; preserve the required pinned terms (Group 1/6/7, pushed workflow, repository-state cleanup, public-readiness, legal/product approval, not sufficient, official/product launch-ready claim) scoped to the paid-hosted/official-product launch path. Image-tag example bumped to `:1.2.1`. |
| `docs/launch-readiness-review-may-8.md` | "Open risk callouts" branch-protection bullet rewritten as a closed-retro note recording the 21-context restoration; operator-approval guard preserved. |
| `docs/launch-candidate-checklist.md` | Group 7 release-check + mutation-cron boxes get inline `_Closed YYYY-MM-DD by …_` annotations matching the existing convention (10+ other instances). **Boxes remain unticked** per operator hard rule. |
| `docs/official-clockify-mcp-gap-analysis.md` | Add a scope-note blockquote at the head of "Blockers for Clockify-supported product launch" explicitly scoping the Tier-3 framing to paid-hosted/"official Clockify" and pointing at the deferred section in the ledger. All required pinned terms preserved. |
| `deploy/k8s/README.md` | Image-tag example bumped `:v1.2.0` → `:1.2.1` with a one-line note explaining the bare-semver convention. |
| `deploy/k8s/base/deployment.yaml` | Same image-tag fix in the actual deploy spec (would have shipped a wrong tag to anyone copying the manifest). |
| `docs/runbooks/image-digest-pinning.md` | Two `:v1.2.0` examples updated to `:1.2.1`. |

### Verifier additions (4 scripts + 1 new + Makefile)

| File | Change |
|---|---|
| `scripts/check-doc-parity.sh` | Phase 3 banned-strings array gets `while this repository is private` and `(requires repo access while private)`. New regex block bans `ghcr.io/<…>:v[0-9]` v-prefixed image tags. |
| `scripts/test-check-doc-parity.sh` | 4 new fixture cases (positive hits for the new private-repo strings, positive hit for `:v1.2.1`, negative case for `:1.2.1` passing). **70/70 → 74/74**. |
| `scripts/check-launch-review-ledger.sh` | Pin the canonical "## Deferred paid-hosted/commercial follow-ups - not required for community/self-hosted v1.2.1" section header + two intro sentences as fixed-string `grep -qF` requirements. The script normalizes Unicode dashes to ASCII hyphen-minus before grep, so the pinned spelling uses ASCII `-` (not em-dash) — this is documented inline. |
| `scripts/test-check-launch-review-ledger.sh` | Baseline fixture gains the deferred-section header; 2 new mutator cases (drop header, drop intro sentence). **39/39 → 41/41**. |
| `scripts/test-release-workflow-structure.sh` (NEW) | Pure assertion script wired into `make script-tests`. Asserts: (a) `release.yml` retains `id: resolve-release-tag` + `GORELEASER_CURRENT_TAG` env pin + v1.2.1 peeled-commit guard; (b) `release-smoke.yml` retains both verification modes + the `IDENT_MODE` regex/literal branching + the v-prefix strip + the loud manual-retry notice; (c) the v1.2.1 SAN exception bounded markers in evidence/verification docs. |
| `Makefile` | `script-tests` target appended with `bash scripts/test-release-workflow-structure.sh`. |

### Test-fixture refactor (no behavior change)

| File | Change |
|---|---|
| `scripts/test-check-launch-evidence-gate.sh` | Test 7 refactored from a sed mutation against the real `launch-candidate-checklist.md` to a synthetic fixture. The real Group 7 row now carries an inline `_Closed_` annotation (from the closure-annotation pass above), so the sed `[ ]` → `[x]` substitution would yield a properly-annotated box that the gate correctly passes — defeating the test's "checked-without-evidence must fail" invariant. Synthetic fixture pattern mirrors Test 8 / Test 9 (Test 8 already did this for the same reason after rc.3). |

## Hard-rule compliance

- ❌ Does **NOT** move, delete, retag, or recreate `v1.2.1` or `v1.2.1-rc.3`.
- ❌ Does **NOT** edit `.github/workflows/release.yml` or `.github/workflows/release-smoke.yml` (the new structure test only ASSERTS what's already there).
- ❌ Does **NOT** modify the v1.2.1 historical release-evidence record (`docs/runbooks/release-candidate-evidence.md` § "v1.2.1 release evidence record (2026-05-10)").
- ❌ Does **NOT** modify the v1.2.1 closure row in `docs/launch-readiness-review-may-8.md` § "Closed gates with evidence anchors".
- ❌ Does **NOT** touch any of the deferred paid-hosted/commercial packet docs.
- ❌ Does **NOT** change branch protection, reopen Issue #78, or modify any auth / policy / RLS / rate-limit defaults.
- ❌ Does **NOT** introduce any "official Clockify", "Cake-approved", "enterprise-ready", or "paid-hosted-ready" claim.
- ❌ Does **NOT** add new Clockify tools, rewrite architecture, or weaken any security/audit/auth/release/evidence gate.

## Verifier results (all green)

- `make doc-parity` → doc-parity / launch-review-ledger / launch-checklist-parity / launch-evidence-gate all OK
- `make launch-checklist-parity` → OK
- `make script-tests` → all 20 suites green (check-doc-parity **74/74** was 70/70; check-launch-review-ledger **41/41** was 39/39; release-workflow-structure tests OK)
- `git diff --check` → exit 0
- `git grep -nF 'while this repository is private'` on user-onboarding paths → empty (only matches inside the new banned-list + fixture-mutator definitions, which IS the regression guard)
- `git grep -nE 'ghcr\.io/[^[:space:]]*:v[0-9]'` on user-onboarding paths → empty (same caveat)

## Definition of done

- ✅ A new public visitor opens README and understands this is an unofficial community/self-hosted Clockify MCP, currently at v1.2.1, with no claims of official Clockify status.
- ✅ No public-facing doc says the repo is private.
- ✅ No launch doc says v1.2.1 is not cut.
- ✅ No community/self-hosted status is incorrectly blocked by deferred paid-hosted/commercial gates.
- ✅ v1.2.1 SAN exception stays documented as bounded one-off; future releases revert to canonical regex; a verifier guards both bounded markers.
- ✅ All four verifier commands pass.

## Related

- v1.2.1 release: https://github.com/apet97/go-clockify/releases/tag/v1.2.1
- PR #94 (`6fe58bd`) — v1.2.1 release evidence + accepted SAN exception
- PR #95 (`85bf92b`) — release-smoke two-mode verification (the work this PR's new structure test asserts cannot regress)
- PR #92 (`2766b39`) — release.yml GORELEASER_CURRENT_TAG pin
- PR #91 (`5206477`) — Linux x64 release-check evidence
- PR #90 (`da7f931`) — paid-hosted scope correction
- PR #89 (`637157d`) — mutation cron equivalent-source closure