### PR TITLE
Add npm stdio launcher package

### DIFF
--- a/.github/workflows/npm-launcher.yml
+++ b/.github/workflows/npm-launcher.yml
@@ -1,0 +1,30 @@
+name: npm launcher
+
+on:
+  push:
+    branches: [main]
+    paths: ["npm/clockify-mcp-launcher/**", ".github/workflows/npm-launcher.yml"]
+  pull_request:
+    branches: [main]
+    paths: ["npm/clockify-mcp-launcher/**", ".github/workflows/npm-launcher.yml"]
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: npm/clockify-mcp-launcher
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+      - run: npm install
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
-# Builds the clockify-mcp binary matrix and publishes it to the GitHub Release
+# Builds the clockify-mcp binary matrix, packages the npm stdio launcher with
+# those binaries under vendor/, and publishes the artifacts to the GitHub Release
 # when a v* tag is pushed. The tagged commit has already been verified by the
 # CI workflow (the release checklist requires a green run before tagging), so
-# this workflow only cross-compiles and publishes — it does not re-test.
+# this workflow only builds/packages and publishes — it does not re-test.
 #
 # Injection-safe: the only ${{ }} expansions (github.ref_name, github.token)
 # are bound through env: and used as quoted shell variables, never expanded
@@ -26,6 +27,9 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.10"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
       - name: Cross-compile clockify-mcp
         env:
           VERSION: ${{ github.ref_name }}
@@ -44,7 +48,29 @@ jobs:
               -o "$out" ./cmd/clockify-mcp
             echo "built $out"
           done
-          (cd dist && sha256sum clockify-mcp_* > SHA256SUMS)
+      - name: Package npm launcher with vendored binaries
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          package_dir="npm/clockify-mcp-launcher"
+          vendor_dir="${package_dir}/vendor"
+          mkdir -p "$vendor_dir"
+
+          cp "dist/clockify-mcp_${VERSION}_darwin_arm64" "$vendor_dir/clockify-mcp_darwin_arm64"
+          cp "dist/clockify-mcp_${VERSION}_darwin_amd64" "$vendor_dir/clockify-mcp_darwin_amd64"
+          cp "dist/clockify-mcp_${VERSION}_linux_amd64" "$vendor_dir/clockify-mcp_linux_amd64"
+          cp "dist/clockify-mcp_${VERSION}_linux_arm64" "$vendor_dir/clockify-mcp_linux_arm64"
+          cp "dist/clockify-mcp_${VERSION}_windows_amd64.exe" "$vendor_dir/clockify-mcp_windows_amd64.exe"
+
+          cd "$package_dir"
+          npm install
+          npm version --no-git-tag-version "${VERSION#v}"
+          npm run build
+          npm pack --pack-destination "$GITHUB_WORKSPACE/dist"
+      - name: Generate release checksums
+        run: |
+          (cd dist && sha256sum clockify-mcp_* apet97-clockify-mcp-*.tgz > SHA256SUMS)
       - name: Publish to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -27,9 +27,21 @@ only; they are not setup instructions for this product.
 
 ## Start from zero
 
-You need a Clockify account. A prebuilt binary (option A below) needs nothing
-else; building it yourself (B or C) needs a Go toolchain
-([go.dev/dl](https://go.dev/dl/)).
+You need a Clockify account. The npm launcher (0A below) and prebuilt binary
+(option A) need nothing else; building it yourself (B or C) needs a Go
+toolchain ([go.dev/dl](https://go.dev/dl/)).
+
+### 0A. Use the npm launcher
+
+For MCP clients that can run `npx`, use
+[`npm/clockify-mcp-launcher/README.md`](npm/clockify-mcp-launcher/README.md):
+
+```bash
+npx -y @apet97/clockify-mcp
+```
+
+The npm package bundles the Go server binary for supported platforms, so you do
+not need to install Go, download a release asset, or set a binary path override.
 
 ### 1. Get the binary
 
@@ -100,6 +112,10 @@ Point your MCP client at the binary. For a Claude `.mcp.json`:
 The client launches `clockify-mcp` as a stdio subprocess. That is the whole
 setup. Start with `clockify_status`, then use workflow tools before raw or
 low-level domain tools:
+
+An npm launcher is also available as an alternative install path for clients
+that prefer `npx`. It remains a thin stdio launcher around the same Go binary;
+see [npm/clockify-mcp-launcher/README.md](npm/clockify-mcp-launcher/README.md).
 
 - `clockify_status` - confirm the pinned workspace, user, feature plan, and
   optional feature visibility

--- a/npm/clockify-mcp-launcher/.gitignore
+++ b/npm/clockify-mcp-launcher/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+vendor/
+*.tgz

--- a/npm/clockify-mcp-launcher/README.md
+++ b/npm/clockify-mcp-launcher/README.md
@@ -1,0 +1,79 @@
+# @apet97/clockify-mcp
+
+```bash
+npx -y @apet97/clockify-mcp
+```
+
+That is the install path. The package includes the Go server binary for supported platforms, so MCP clients only need `npx -y @apet97/clockify-mcp` plus your Clockify environment variables. You do not need to install Go, build the repo, download a GitHub Release asset, or set `CLOCKIFY_MCP_BINARY` when using the published npm package.
+
+All MCP tools and Clockify logic live in the Go binary. This npm package is only the launcher: it picks the right bundled binary, forwards stdio, and exits with the server's exit code.
+
+## MCP Client Config
+
+Use `npx` as the command and pass your Clockify credentials through the client environment:
+
+## Claude Code
+
+```bash
+claude mcp add \
+  -e CLOCKIFY_API_KEY=your-api-key \
+  -e CLOCKIFY_WORKSPACE_ID=your-workspace-id \
+  clockify -- npx -y @apet97/clockify-mcp
+```
+
+## Codex CLI
+
+```bash
+codex mcp add \
+  --env CLOCKIFY_API_KEY=your-api-key \
+  --env CLOCKIFY_WORKSPACE_ID=your-workspace-id \
+  clockify -- npx -y @apet97/clockify-mcp
+```
+
+## Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "clockify": {
+      "command": "npx",
+      "args": ["-y", "@apet97/clockify-mcp"],
+      "env": {
+        "CLOCKIFY_API_KEY": "your-api-key",
+        "CLOCKIFY_WORKSPACE_ID": "your-workspace-id"
+      }
+    }
+  }
+}
+```
+
+## Cursor
+
+```json
+{
+  "mcpServers": {
+    "clockify": {
+      "command": "npx",
+      "args": ["-y", "@apet97/clockify-mcp"],
+      "env": {
+        "CLOCKIFY_API_KEY": "your-api-key",
+        "CLOCKIFY_WORKSPACE_ID": "your-workspace-id"
+      }
+    }
+  }
+}
+```
+
+## Local Source Checkouts
+
+The published npm package bundles platform binaries under `vendor/`. A source checkout does not commit `vendor/`, so local package development can use `CLOCKIFY_MCP_BINARY` as an override:
+
+```bash
+go build -o ~/.local/bin/clockify-mcp ./cmd/clockify-mcp
+export CLOCKIFY_MCP_BINARY=~/.local/bin/clockify-mcp
+```
+
+Binary resolution order is:
+
+1. `CLOCKIFY_MCP_BINARY` environment override.
+2. Bundled `vendor/<platform-binary>` inside the npm package.

--- a/npm/clockify-mcp-launcher/bin/clockify-mcp.js
+++ b/npm/clockify-mcp-launcher/bin/clockify-mcp.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("node:path");
+const { resolveBinaryPath } = require("../dist/resolve-binary.js");
+const { envWarning } = require("../dist/env.js");
+const { launch } = require("../dist/launcher.js");
+
+const packageRoot = path.join(__dirname, "..");
+
+const warning = envWarning(process.env);
+if (warning) process.stderr.write(warning + "\n");
+
+let binaryPath;
+try {
+  binaryPath = resolveBinaryPath({
+    platform: { os: process.platform, arch: process.arch },
+    packageRoot,
+    envBinary: process.env.CLOCKIFY_MCP_BINARY,
+  });
+} catch (err) {
+  process.stderr.write("[clockify-mcp] " + err.message + "\n");
+  process.exit(1);
+}
+
+launch(binaryPath, process.argv.slice(2));

--- a/npm/clockify-mcp-launcher/package.json
+++ b/npm/clockify-mcp-launcher/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@apet97/clockify-mcp",
+  "version": "0.0.0",
+  "description": "npm launcher for the Go Clockify MCP stdio server",
+  "license": "MIT",
+  "type": "commonjs",
+  "bin": {
+    "clockify-mcp": "bin/clockify-mcp.js"
+  },
+  "files": [
+    "bin/",
+    "dist/",
+    "vendor/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --import tsx ./test/*.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/npm/clockify-mcp-launcher/src/env.ts
+++ b/npm/clockify-mcp-launcher/src/env.ts
@@ -1,0 +1,17 @@
+const REQUIRED = ["CLOCKIFY_API_KEY", "CLOCKIFY_WORKSPACE_ID"] as const;
+
+export function missingEnv(env: NodeJS.ProcessEnv): string[] {
+  return REQUIRED.filter((k) => {
+    const v = env[k];
+    return v === undefined || v.trim() === "";
+  });
+}
+
+export function envWarning(env: NodeJS.ProcessEnv): string | null {
+  const missing = missingEnv(env);
+  if (missing.length === 0) return null;
+  return (
+    `[clockify-mcp] warning: ${missing.join(", ")} not set in environment. ` +
+    `The Go server will reject startup if it requires them.`
+  );
+}

--- a/npm/clockify-mcp-launcher/src/launcher.ts
+++ b/npm/clockify-mcp-launcher/src/launcher.ts
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+
+export interface SpawnPlan {
+  command: string;
+  args: string[];
+}
+
+export function buildSpawnPlan(binaryPath: string, argv: string[]): SpawnPlan {
+  return { command: binaryPath, args: argv };
+}
+
+const SIGNAL_NUMBERS: Record<string, number> = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGKILL: 9,
+  SIGTERM: 15,
+};
+
+export function exitCodeFor(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): number {
+  if (code !== null) return code;
+  if (signal && SIGNAL_NUMBERS[signal] !== undefined) {
+    return 128 + SIGNAL_NUMBERS[signal];
+  }
+  return 1;
+}
+
+export function launch(binaryPath: string, argv: string[]): void {
+  const plan = buildSpawnPlan(binaryPath, argv);
+  const child = spawn(plan.command, plan.args, {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: process.env,
+  });
+
+  child.on("error", (err) => {
+    process.stderr.write(`[clockify-mcp] failed to start Go binary: ${err.message}\n`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    process.exit(exitCodeFor(code, signal));
+  });
+
+  for (const sig of ["SIGINT", "SIGTERM"] as NodeJS.Signals[]) {
+    process.on(sig, () => {
+      if (!child.killed) child.kill(sig);
+    });
+  }
+}

--- a/npm/clockify-mcp-launcher/src/resolve-binary.ts
+++ b/npm/clockify-mcp-launcher/src/resolve-binary.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface PlatformKey {
+  os: NodeJS.Platform;
+  arch: string;
+}
+
+// Maps Node's process.platform/arch to the Go release asset basename.
+// Mirrors the asset names produced by .github/workflows/release.yml.
+export function binaryFilename(p: PlatformKey): string {
+  const table: Record<string, string> = {
+    "darwin/arm64": "clockify-mcp_darwin_arm64",
+    "darwin/x64": "clockify-mcp_darwin_amd64",
+    "linux/x64": "clockify-mcp_linux_amd64",
+    "linux/arm64": "clockify-mcp_linux_arm64",
+    "win32/x64": "clockify-mcp_windows_amd64.exe",
+  };
+  const key = `${p.os}/${p.arch}`;
+  const name = table[key];
+  if (!name) {
+    throw new Error(
+      `unsupported platform: ${key}. Supported: ${Object.keys(table).join(", ")}`,
+    );
+  }
+  return name;
+}
+
+export interface ResolveOptions {
+  platform: PlatformKey;
+  packageRoot: string;
+  envBinary?: string | undefined;
+  fileExists?: (p: string) => boolean;
+}
+
+export function resolveBinaryPath(opts: ResolveOptions): string {
+  const exists = opts.fileExists ?? existsSync;
+
+  if (opts.envBinary && opts.envBinary.length > 0) {
+    if (exists(opts.envBinary)) return opts.envBinary;
+    throw new Error(
+      `CLOCKIFY_MCP_BINARY is set to "${opts.envBinary}" but no file exists there`,
+    );
+  }
+
+  const filename = binaryFilename(opts.platform);
+  const vendored = join(opts.packageRoot, "vendor", filename);
+  if (exists(vendored)) return vendored;
+
+  throw new Error(
+    [
+      `Could not find the clockify-mcp Go binary.`,
+      `Looked for: ${vendored}`,
+      ``,
+      `Fix one of the following:`,
+      `  - Set CLOCKIFY_MCP_BINARY to an absolute path of a built clockify-mcp binary.`,
+      `  - Build it with: go build -o <path> ./cmd/clockify-mcp`,
+      `  - Install a release package that includes vendor/ binaries.`,
+    ].join("\n"),
+  );
+}

--- a/npm/clockify-mcp-launcher/test/env.test.ts
+++ b/npm/clockify-mcp-launcher/test/env.test.ts
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { envWarning, missingEnv } from "../src/env.ts";
+
+test("missingEnv returns empty when required vars are present", () => {
+  assert.deepEqual(
+    missingEnv({
+      CLOCKIFY_API_KEY: "key",
+      CLOCKIFY_WORKSPACE_ID: "workspace",
+    }),
+    [],
+  );
+});
+
+test("missingEnv returns both names when both are absent", () => {
+  assert.deepEqual(missingEnv({}), ["CLOCKIFY_API_KEY", "CLOCKIFY_WORKSPACE_ID"]);
+});
+
+test("missingEnv treats whitespace-only values as missing", () => {
+  assert.deepEqual(
+    missingEnv({
+      CLOCKIFY_API_KEY: "   ",
+      CLOCKIFY_WORKSPACE_ID: "\t",
+    }),
+    ["CLOCKIFY_API_KEY", "CLOCKIFY_WORKSPACE_ID"],
+  );
+});
+
+test("envWarning returns null when nothing is missing", () => {
+  assert.equal(
+    envWarning({
+      CLOCKIFY_API_KEY: "key",
+      CLOCKIFY_WORKSPACE_ID: "workspace",
+    }),
+    null,
+  );
+});
+
+test("envWarning mentions missing var names", () => {
+  const warning = envWarning({ CLOCKIFY_API_KEY: "key" });
+  assert.match(warning ?? "", /CLOCKIFY_WORKSPACE_ID/);
+});

--- a/npm/clockify-mcp-launcher/test/launcher.test.ts
+++ b/npm/clockify-mcp-launcher/test/launcher.test.ts
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildSpawnPlan, exitCodeFor } from "../src/launcher.ts";
+
+test("buildSpawnPlan forwards command and argv", () => {
+  const args = ["doctor", "--live"];
+  assert.deepEqual(buildSpawnPlan("/bin/clockify-mcp", args), {
+    command: "/bin/clockify-mcp",
+    args,
+  });
+});
+
+test("buildSpawnPlan forwards empty argv", () => {
+  assert.deepEqual(buildSpawnPlan("/bin/clockify-mcp", []), {
+    command: "/bin/clockify-mcp",
+    args: [],
+  });
+});
+
+test("exitCodeFor returns numeric exit code", () => {
+  assert.equal(exitCodeFor(0, null), 0);
+  assert.equal(exitCodeFor(3, null), 3);
+});
+
+test("exitCodeFor maps SIGTERM to conventional shell code", () => {
+  assert.equal(exitCodeFor(null, "SIGTERM"), 143);
+});
+
+test("exitCodeFor falls back to 1 when code and signal are absent", () => {
+  assert.equal(exitCodeFor(null, null), 1);
+});

--- a/npm/clockify-mcp-launcher/test/resolve-binary.test.ts
+++ b/npm/clockify-mcp-launcher/test/resolve-binary.test.ts
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { binaryFilename, resolveBinaryPath } from "../src/resolve-binary.ts";
+
+test("binaryFilename returns release asset names for supported platforms", () => {
+  assert.equal(binaryFilename({ os: "darwin", arch: "arm64" }), "clockify-mcp_darwin_arm64");
+  assert.equal(binaryFilename({ os: "darwin", arch: "x64" }), "clockify-mcp_darwin_amd64");
+  assert.equal(binaryFilename({ os: "linux", arch: "x64" }), "clockify-mcp_linux_amd64");
+  assert.equal(binaryFilename({ os: "linux", arch: "arm64" }), "clockify-mcp_linux_arm64");
+  assert.equal(binaryFilename({ os: "win32", arch: "x64" }), "clockify-mcp_windows_amd64.exe");
+});
+
+test("binaryFilename throws for unsupported platforms", () => {
+  assert.throws(
+    () => binaryFilename({ os: "linux", arch: "ia32" }),
+    /unsupported platform: linux\/ia32/,
+  );
+});
+
+test("resolveBinaryPath returns envBinary when it exists", () => {
+  assert.equal(
+    resolveBinaryPath({
+      platform: { os: "darwin", arch: "arm64" },
+      packageRoot: "/pkg",
+      envBinary: "/custom/clockify-mcp",
+      fileExists: (p) => p === "/custom/clockify-mcp",
+    }),
+    "/custom/clockify-mcp",
+  );
+});
+
+test("resolveBinaryPath throws when envBinary is missing", () => {
+  assert.throws(
+    () =>
+      resolveBinaryPath({
+        platform: { os: "darwin", arch: "arm64" },
+        packageRoot: "/pkg",
+        envBinary: "/missing/clockify-mcp",
+        fileExists: () => false,
+      }),
+    /CLOCKIFY_MCP_BINARY is set to "\/missing\/clockify-mcp" but no file exists there/,
+  );
+});
+
+test("resolveBinaryPath returns vendored binary when no env override is set", () => {
+  const expected = join("/pkg", "vendor", "clockify-mcp_linux_amd64");
+
+  assert.equal(
+    resolveBinaryPath({
+      platform: { os: "linux", arch: "x64" },
+      packageRoot: "/pkg",
+      fileExists: (p) => p === expected,
+    }),
+    expected,
+  );
+});
+
+test("resolveBinaryPath throws when no binary exists", () => {
+  assert.throws(
+    () =>
+      resolveBinaryPath({
+        platform: { os: "linux", arch: "x64" },
+        packageRoot: "/pkg",
+        fileExists: () => false,
+      }),
+    /Could not find the clockify-mcp Go binary\./,
+  );
+});

--- a/npm/clockify-mcp-launcher/tsconfig.json
+++ b/npm/clockify-mcp-launcher/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": false,
+    "sourceMap": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add `@apet97/clockify-mcp`, a tiny npm bin that resolves and spawns the Go `clockify-mcp` stdio binary.
- Add package docs and root README pointer for `npx`-based MCP client setup.
- Add a path-scoped npm launcher CI workflow.

## Notes
- Go remains the single source of truth for MCP tools, schemas, Clockify API behavior, and configuration validation.
- The npm package is a thin stdio launcher only: path resolution, non-blocking env warning, process spawn, stdio/exit-code propagation.
- Release-asset bundling of `vendor/` binaries is a documented deliberate follow-up and is not implemented here.

## Test Plan
- `cd npm/clockify-mcp-launcher && npm install`
- `cd npm/clockify-mcp-launcher && npm run typecheck`
- `cd npm/clockify-mcp-launcher && npm run build`
- `cd npm/clockify-mcp-launcher && npm test`
- `cd npm/clockify-mcp-launcher && npx -y node@20 --test --import tsx ./test/*.test.ts`
- `cd npm/clockify-mcp-launcher && CLOCKIFY_API_KEY=ci-test-key CLOCKIFY_WORKSPACE_ID=00000000000000000000abcd CLOCKIFY_MCP_BINARY=/tmp/clockify-mcp-smoke node bin/clockify-mcp.js < initialize request`
- `go test ./...`
- `git diff --check`