### PR TITLE
feat(gen): quarantine 3 more phantom routes (G.1 edge-case sweep)

### DIFF
--- a/docs/openapi/clockify-openapi.yaml
+++ b/docs/openapi/clockify-openapi.yaml
@@ -10964,48 +10964,6 @@ paths:
       x-fern-sdk-group-name: timeOff
       x-fern-sdk-method-name: submitForUser
   "/workspaces/{workspaceId}/time-off/requests":
-    get:
-      tags:
-      - Balances
-      summary: Get all time off requests
-      operationId: getWorkspacesWorkspaceIdTimeOffRequests
-      security:
-      - ApiKeyAuth: []
-      - AddonTokenAuth: []
-      parameters:
-      - in: path
-        name: workspaceId
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  count:
-                    type: integer
-                  requests:
-                    items:
-                      "$ref": "#/components/schemas/BalanceTimeOffRequest"
-                    type: array
-                type: object
-          description: List of requests
-      x-clockify-evidence:
-      - probe-supplement
-      - unsupported
-      x-clockify-host: https://api.clockify.me/api/v1
-      x-clockify-live-status: unsupported
-      x-clockify-mcp-tools: []
-      x-clockify-notes:
-      - "| GET | api.clockify.me | /api/v1/workspaces/{ws}/time-off/requests | 405
-        | fixtures/time-off/requests-get-broken.json |"
-      x-clockify-risk:
-      - read
-      x-clockify-source-files:
-      - clockify-api-probe-lab/findings/time-off.md
-      - clockify-api-probe-lab/inveoice+Balance+Policies+TimeOff.yaml
     post:
       tags:
       - Time Off
@@ -11066,48 +11024,6 @@ paths:
       - realOPENAPI/TIMEOFFOPENAPI.YAML
       x-fern-sdk-group-name: timeOff
       x-fern-sdk-method-name: list
-  "/workspaces/{workspaceId}/time-off/requests/users/{userId}":
-    post:
-      tags:
-      - Time Off
-      summary: Create time-off request for user
-      operationId: postWorkspacesWorkspaceIdTimeOffRequestsUsersUserId
-      security:
-      - ApiKeyAuth: []
-      - AddonTokenAuth: []
-      parameters:
-      - in: path
-        name: workspaceId
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: userId
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/TimeOffRequestCreate"
-        required: true
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/TimeOffRequest"
-          description: Created
-      x-clockify-evidence:
-      - probe-openapi
-      x-clockify-host: https://api.clockify.me/api/v1
-      x-clockify-live-status: probe-documented
-      x-clockify-mcp-tools: []
-      x-clockify-risk:
-      - write
-      x-clockify-source-files:
-      - clockify-api-probe-lab/openapi.yaml
   "/workspaces/{workspaceId}/time-off/requests/{requestId}":
     get:
       tags:
@@ -13212,51 +13128,6 @@ paths:
       - clockify-api-probe-lab/USEREXPENCUSTOMFIED.yaml
       - clockify-api-probe-lab/openapi.yaml
       - realOPENAPI/USEROPENAPI.YAML
-  "/workspaces/{workspaceId}/users/{userId}/time-off/balances":
-    get:
-      tags:
-      - Balances
-      summary: Get balance for a user
-      operationId: getWorkspacesWorkspaceIdUsersUserIdTimeOffBalances
-      security:
-      - ApiKeyAuth: []
-      - AddonTokenAuth: []
-      parameters:
-      - in: path
-        name: workspaceId
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: userId
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  balances:
-                    items:
-                      "$ref": "#/components/schemas/BalanceBalance"
-                    type: array
-                  count:
-                    type: integer
-                type: object
-          description: User balances
-      x-clockify-evidence:
-      - probe-supplement
-      x-clockify-host: https://api.clockify.me/api/v1
-      x-clockify-live-status: probe-documented
-      x-clockify-mcp-tools: []
-      x-clockify-risk:
-      - read
-      x-clockify-source-files:
-      - clockify-api-probe-lab/inveoice+Balance+Policies+TimeOff.yaml
-      x-fern-sdk-group-name: balances
-      x-fern-sdk-method-name: listForUser
   "/workspaces/{workspaceId}/webhooks":
     get:
       tags:
@@ -15026,29 +14897,6 @@ components:
       required:
       - defaultEntities
       type: object
-    BalanceBalance:
-      properties:
-        balance:
-          type: number
-        id:
-          type: string
-        policyId:
-          type: string
-        policyName:
-          type: string
-        policyTimeUnit:
-          type: string
-        total:
-          type: number
-        used:
-          type: number
-        userId:
-          type: string
-        userName:
-          type: string
-        workspaceId:
-          type: string
-      type: object
     BalanceDtoV1:
       description: Balance data transfer object.
       properties:
@@ -15130,38 +14978,6 @@ components:
       - ASCENDING
       - DESCENDING
       type: string
-    BalanceTimeOffRequest:
-      properties:
-        balance:
-          type: number
-        balanceDiff:
-          type: number
-        createdAt:
-          type: string
-        id:
-          type: string
-        note:
-          type: string
-        policyId:
-          type: string
-        policyName:
-          type: string
-        status:
-          properties:
-            note:
-              type: string
-            statusType:
-              type: string
-          type: object
-        timeOffPeriod:
-          type: object
-        timeUnit:
-          type: string
-        userId:
-          type: string
-        workspaceId:
-          type: string
-      type: object
     BaseFilterRequest:
       description: Represents a base filter object.
       properties:
@@ -21252,25 +21068,6 @@ components:
         workspaceId:
           type: string
       type: object
-    TimeOffRequestCreate:
-      properties:
-        note:
-          type: string
-        policyId:
-          type: string
-        timeOffPeriod:
-          properties:
-            halfDay:
-              type: boolean
-            period:
-              "$ref": "#/components/schemas/DateTimeInterval"
-          required:
-          - period
-          type: object
-      required:
-      - policyId
-      - timeOffPeriod
-      type: object
     TimeOffRequestDto:
       description: Represents a time off request response.
       example:
@@ -23774,6 +23571,12 @@ x-clockify-generation:
     ReportAddonKeyAuth:
     - x-addon-token
 x-clockify-source-quarantine:
+- source: clockify-api-probe-lab/inveoice+Balance+Policies+TimeOff.yaml
+  reason: 'phantom path quarantined (GET /workspaces/{workspaceId}/time-off/requests):
+    see PHANTOM_PATHS in scripts/gen-clockify-openapi'
+- source: clockify-api-probe-lab/inveoice+Balance+Policies+TimeOff.yaml
+  reason: 'phantom path quarantined (GET /workspaces/{workspaceId}/users/{userId}/time-off/balances):
+    see PHANTOM_PATHS in scripts/gen-clockify-openapi'
 - source: clockify-api-probe-lab/openapi-fragments/expenses-a.yaml
   reason: invalid YAML source quarantined
 - source: clockify-api-probe-lab/openapi-fragments/policies-a.yaml
@@ -23808,5 +23611,8 @@ x-clockify-source-quarantine:
 - source: clockify-api-probe-lab/openapi.yaml
   reason: 'phantom path quarantined (PATCH /workspaces/{workspaceId}/balance): see
     PHANTOM_PATHS in scripts/gen-clockify-openapi'
+- source: clockify-api-probe-lab/openapi.yaml
+  reason: 'phantom path quarantined (POST /workspaces/{workspaceId}/time-off/requests/users/{userId}):
+    see PHANTOM_PATHS in scripts/gen-clockify-openapi'
 - source: clockify-api-probe-lab/openapi_scheduling.yaml
   reason: invalid YAML source quarantined

--- a/internal/tools/raw_allowlist_gen.go
+++ b/internal/tools/raw_allowlist_gen.go
@@ -141,7 +141,6 @@ var documentedWriteRoutes = map[string]bool{
 	"POST /workspaces/{workspaceId}/time-off/policies/{policyId}/requests":                true,
 	"POST /workspaces/{workspaceId}/time-off/policies/{policyId}/users/{userId}/requests": true,
 	"POST /workspaces/{workspaceId}/time-off/requests":                                    true,
-	"POST /workspaces/{workspaceId}/time-off/requests/users/{userId}":                     true,
 	"PUT /workspaces/{workspaceId}/time-off/policies/{policyId}":                          true,
 
 	// user

--- a/scripts/gen-clockify-openapi
+++ b/scripts/gen-clockify-openapi
@@ -475,7 +475,39 @@ PHANTOM_PATHS = [
   # requests.phantom-path-quarantined`.
   ["post",   "/workspaces/{workspaceId}/policies/{policyId}/requests"],
   ["delete", "/workspaces/{workspaceId}/policies/{policyId}/requests/{requestId}"],
-  ["patch",  "/workspaces/{workspaceId}/policies/{policyId}/requests/{requestId}"]
+  ["patch",  "/workspaces/{workspaceId}/policies/{policyId}/requests/{requestId}"],
+  # Three additional phantoms surfaced during the G.1 domain
+  # edge-case sweep (2026-05-25 re-probe, sandbox 65b382b606de527a7ee2b60e):
+  #
+  # - POST /workspaces/{wsId}/time-off/requests/users/{userId} ->
+  #   HTTP 404 + code 3000 "No static resource". Looked like an
+  #   admin "create TOR for a specific user via the workspace-level
+  #   path" but doesn't exist; the live equivalent is the policy-
+  #   scoped `submitForUser` at /time-off/policies/{pid}/users/
+  #   {uid}/requests.
+  # - GET /workspaces/{wsId}/time-off/requests -> HTTP 405 + code
+  #   3000 "Request method 'GET' is not supported". The path
+  #   exists for POST (that's `list`, the documented POST-as-list
+  #   quirk) but GET is not allowed. The canonical's own
+  #   x-clockify-notes block on this op already documents the 405
+  #   from a prior probe-supplement -- the quarantine just stops
+  #   us from generating an SDK method that immediately 405s.
+  # - GET /workspaces/{wsId}/users/{userId}/time-off/balances ->
+  #   HTTP 404 + code 3000 "No static resource". Looked like a
+  #   per-user time-off balances list across all policies, but
+  #   doesn't exist; the live per-user balance read is the
+  #   singular /time-off/balance/user/{userId} (already stamped
+  #   as balances.getForUser).
+  #
+  # Probe fixtures (gitignored):
+  # - addons-me/fern/spec/evidence/probes/20260525-edge-post-tor-users-userid.{json,hdr}
+  # - addons-me/fern/spec/evidence/probes/20260525-edge-get-tor.{json,hdr}
+  # - addons-me/fern/spec/evidence/probes/20260525-edge-get-user-balances.{json,hdr}
+  # Ledger update lives under
+  # discrepancies.md > timeoff.legacy-policies-requests.phantom-path-quarantined.
+  ["post", "/workspaces/{workspaceId}/time-off/requests/users/{userId}"],
+  ["get",  "/workspaces/{workspaceId}/time-off/requests"],
+  ["get",  "/workspaces/{workspaceId}/users/{userId}/time-off/balances"]
 ].freeze
 
 def phantom_path?(method, path)
@@ -1212,12 +1244,15 @@ SDK_METHOD_NAMES = {
   # - timeOff DELETE on the policy-scoped request path is the user-
   #   side withdraw flow (admin DELETE on the workspace-level
   #   `/time-off/requests/{rid}` was stamped as `delete`).
-  # - balances GET on the per-user `/users/{uid}/time-off/balances`
-  #   plural route returns a list of balances across policies; the
-  #   sibling singular `getForUser` returns a single balance object.
+  # - The third v0.5.0 edge-case stamp (`balances.listForUser` on GET
+  #   /users/{userId}/time-off/balances) was removed in the
+  #   2026-05-25 follow-up after the route was confirmed phantom on
+  #   the live API (HTTP 404 + code 3000). That path now lives in
+  #   PHANTOM_PATHS; the live per-user balance read is the singular
+  #   `/time-off/balance/user/{userId}` (already stamped as
+  #   `balances.getForUser`).
   ["post",   "/workspaces/{workspaceId}/projects/{projectId}/memberships"]                        => {group: "projects", name: "setMembers"},
-  ["delete", "/workspaces/{workspaceId}/time-off/policies/{policyId}/requests/{requestId}"]       => {group: "timeOff", name: "withdraw"},
-  ["get",    "/workspaces/{workspaceId}/users/{userId}/time-off/balances"]                        => {group: "balances", name: "listForUser"}
+  ["delete", "/workspaces/{workspaceId}/time-off/policies/{policyId}/requests/{requestId}"]       => {group: "timeOff", name: "withdraw"}
 }.freeze
 
 def stamp_sdk_method_name!(op, method, path)

--- a/tests/doc_parity_test.go
+++ b/tests/doc_parity_test.go
@@ -147,17 +147,21 @@ func TestHistoricalPlatformDocsCarryBanner(t *testing.T) {
 func TestGeneratedOpenAPIContractMeetsCoverageFloor(t *testing.T) {
 	contract := readOpenAPIContract(t, filepath.Join("..", "docs", "openapi", "clockify-openapi.yaml"))
 
-	// Floor counts updated 2026-05-25 after quarantining 3 phantom
-	// time-off-request /policies/{policyId}/requests routes (POST +
-	// DELETE + PATCH) — see addons-me/fern/spec/evidence/discrepancies.md
-	// > timeoff.legacy-policies-requests.phantom-path-quarantined.
-	// The quarantined ops returned HTTP 404 + code 3000 ("No static
-	// resource") on the live API; they were spec ghosts from an
-	// older clockify-api-probe-lab source-bundle revision.
-	if got, want := len(contract.paths), 123; got < want {
+	// Floor counts updated 2026-05-25 after quarantining 6 phantom
+	// routes total. Round 1 (3 ops, 2 paths): legacy time-off-request
+	// /policies/{policyId}/requests trio (POST + DELETE + PATCH).
+	// Round 2 (3 ops, 2 paths): G.1 edge-case sweep — POST
+	// /time-off/requests/users/{userId} (404 live), GET /time-off/
+	// requests (405 live; POST remains as the documented POST-as-list),
+	// GET /users/{userId}/time-off/balances (404 live). All probed
+	// against sandbox 65b382b606de527a7ee2b60e on 2026-05-25; all
+	// returned Clockify error code 3000. See addons-me/fern/spec/
+	// evidence/discrepancies.md > timeoff.legacy-policies-requests.
+	// phantom-path-quarantined for the full audit.
+	if got, want := len(contract.paths), 121; got < want {
 		t.Fatalf("OpenAPI path count shrank: got %d want at least %d", got, want)
 	}
-	if got, want := contract.operationCount(), 188; got < want {
+	if got, want := contract.operationCount(), 185; got < want {
 		t.Fatalf("OpenAPI operation count shrank: got %d want at least %d", got, want)
 	}
 
@@ -176,7 +180,13 @@ func TestGeneratedOpenAPIContractMeetsCoverageFloor(t *testing.T) {
 		{method: "patch", path: "/workspaces/{workspaceId}/time-off/requests/{requestId}/status"},
 		{method: "get", path: "/workspaces/{workspaceId}/time-off/balance/user/{userId}"},
 		{method: "patch", path: "/workspaces/{workspaceId}/time-off/balance/policy/{policyId}"},
-		{method: "get", path: "/workspaces/{workspaceId}/users/{userId}/time-off/balances"},
+		// `GET /workspaces/{workspaceId}/users/{userId}/time-off/balances`
+		// was removed from this required list when the G.1 edge-case
+		// re-probe (2026-05-25) confirmed the route returns HTTP 404
+		// + Clockify error code 3000 on the live API. It is now in
+		// PHANTOM_PATHS. The live per-user balance read is the
+		// singular `/time-off/balance/user/{userId}` -- still asserted
+		// above.
 		{method: "post", path: "/workspaces/{workspaceId}/scheduling/assignments"},
 		{method: "get", path: "/workspaces/{workspaceId}/scheduling/assignments/all"},
 		{method: "post", path: "/workspaces/{workspaceId}/scheduling/assignments/projects/totals"},


### PR DESCRIPTION
## Summary

Follow-up to PR #137. Probes the three "needs investigation"
routes that were deferred out of v0.5.0 and confirms all three
are dead on the live API (HTTP 404/405 + Clockify error code
3000). Adds them to PHANTOM_PATHS so the canonical no longer
declares ops that immediately fail when called.

- `POST /workspaces/{wsId}/time-off/requests/users/{userId}` → 404
- `GET /workspaces/{wsId}/time-off/requests` → 405 (POST live, kept)
- `GET /workspaces/{wsId}/users/{userId}/time-off/balances` → 404

PHANTOM_PATHS grows from 6 → 9; canonical operations 188 → 185;
raw-allowlist 131 → 130. Test floors updated (paths 123 → 121,
ops 188 → 185); the required-operations list drops the now-phantom
`GET /users/{userId}/time-off/balances`.

## Verification

- `make gen-openapi` deterministic + clean.
- All 4 drift gates pass (`openapi-drift`, `catalog-drift`,
  `selfinspect-drift`, `raw-allowlist-drift`).
- `go test ./internal/tools/...` ok.
- `go test ./tests/...` ok (was failing on the requiredOperations
  check until I dropped the quarantined op from the list).
- Downstream `fern check --warnings --from-openapi` ✓.
- Downstream `fern generate --group ts --local --force` ✓.
- Downstream wrapper `npm run type-check` + 126/126 vitest +
  build + smoke + `npm pack --dry-run` (5724 entries matching
  baseline) all green.

Probe fixtures (gitignored downstream):
- `addons-me/fern/spec/evidence/probes/20260525-edge-post-tor-users-userid.{json,hdr}`
- `addons-me/fern/spec/evidence/probes/20260525-edge-get-tor.{json,hdr}`
- `addons-me/fern/spec/evidence/probes/20260525-edge-get-user-balances.{json,hdr}`

## Test plan

- [ ] CI passes on this PR head.
- [ ] After merge, the wrapper PR (`apet97/clockify-ts-sdk#TBD`)
  picks up the new canonical via `npm run sync`.