### PR TITLE
fix(spec): restore Client.ccEmails/currencyId + pin audit-log source + manifest completeness check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,19 @@ as setup instructions.
 
 ## Current State
 
+- **Schema-fidelity fixes + manifest completeness (2026-06-23).** A live-wire audit
+  found a thin `clockify-api-probe-lab/openapi.yaml` schema winning the generator's
+  first-writer schema-name race and dropping fields the live API returns. Restored
+  `Client.ccEmails`/`currencyId`; corrected the `SharedReport` response shape
+  (`isPublic` not `public`, `link` not `url`, plus `reportAuthor`/`visibleToUsers`/
+  `visibleToUserGroups`/`fixedDate`/`workspaceId`/`userId`; dropped phantom
+  `url`/`createdAt`/`updatedAt`/`workspace`); fixed the `SharedReportCreate` request
+  field to `isPublic` (the API silently ignores `public` — live-proved); added
+  `Webhook.deliveryEnabled`/`planEnabled`. Op count unchanged (169). Also pinned the
+  previously-unpinned `clockify-api-probe-lab/openapi-fragments/audit-log.yaml` source
+  and added a reverse-completeness check to `validate_source_manifest!`: any consumed
+  openapi fragment that is not pinned now aborts generation.
+
 - **Read-tier live-success wave + list pagination (2026-06-20).** A live read
   probe of the sacrificial sandbox promoted 21 GET ops from `probe-documented`
   to `x-clockify-live-status: live-success` (user/workspaces/user-groups/users/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored response fields the live API returns that a thin
+  `clockify-api-probe-lab/openapi.yaml` schema had shadowed (the generator resolves
+  schema-name collisions first-writer-wins): `Client.ccEmails`/`currencyId`; the
+  `SharedReport` response shape (`isPublic` not `public`, `link` not `url`, plus
+  `reportAuthor`/`visibleToUsers`/`visibleToUserGroups`/`fixedDate`/`workspaceId`/
+  `userId`; dropped the phantom `url`/`createdAt`/`updatedAt`/`workspace`); the
+  `SharedReportCreate` request field `isPublic` (sending `public` is silently ignored by
+  the API — live-verified); and `Webhook.deliveryEnabled`/`planEnabled`. Op count
+  unchanged (169).
+- Pinned `clockify-api-probe-lab/openapi-fragments/audit-log.yaml` in the source manifest
+  (consumed by the generator but previously unpinned) and added a reverse-completeness
+  check to `validate_source_manifest!`: any consumed openapi fragment that is not pinned
+  now aborts generation.
+
 ### Added
 
 - Live read-probe wave promotes 21 GET operations from `probe-documented` to

--- a/docs/openapi/clockify-openapi.yaml
+++ b/docs/openapi/clockify-openapi.yaml
@@ -19924,33 +19924,43 @@ components:
       type: string
     SharedReport:
       properties:
-        createdAt:
-          format: date-time
-          type: string
         filter:
           "$ref": "#/components/schemas/SharedReportFilter"
+        fixedDate:
+          nullable: true
+          type: boolean
         id:
+          type: string
+        isPublic:
+          type: boolean
+        link:
+          nullable: true
           type: string
         name:
           type: string
-        public:
-          type: boolean
+        reportAuthor:
+          nullable: true
+          type: string
         type:
           "$ref": "#/components/schemas/SharedReportCreate/properties/type"
-        updatedAt:
-          format: date-time
+        userId:
+          nullable: true
           type: string
-        url:
+        visibleToUserGroups:
+          items:
+            additionalProperties: true
+            type: object
+          nullable: true
+          type: array
+        visibleToUsers:
+          items:
+            additionalProperties: true
+            type: object
+          nullable: true
+          type: array
+        workspaceId:
+          nullable: true
           type: string
-        workspace:
-          properties:
-            id:
-              type: string
-            name:
-              type: string
-            workspaceSettings:
-              "$ref": "#/components/schemas/WorkspaceSettings"
-          type: object
       type: object
     SharedReportCreate:
       description: |
@@ -19960,10 +19970,10 @@ components:
       properties:
         filter:
           "$ref": "#/components/schemas/SharedReportFilter"
+        isPublic:
+          type: boolean
         name:
           type: string
-        public:
-          type: boolean
         type:
           enum:
           - SUMMARY
@@ -22585,6 +22595,9 @@ components:
         authToken:
           description: HMAC secret. Treat as a credential; never log.
           type: string
+        deliveryEnabled:
+          nullable: true
+          type: boolean
         enabled:
           type: boolean
         id:
@@ -22592,6 +22605,9 @@ components:
         name:
           nullable: true
           type: string
+        planEnabled:
+          nullable: true
+          type: boolean
         triggerSource:
           items:
             type: string
@@ -23384,15 +23400,6 @@ components:
             "$ref": "#/components/schemas/ExpenseWeeklyTotalsDtoV1"
           type: array
       type: object
-    WorkspaceSettings:
-      additionalProperties: true
-      description: |
-        Workspace settings is a large, mostly-flat dictionary (~80 keys)
-        controlling features (timeRoundingInReports, lockTimeEntries,
-        timeFormat, decimalFormat, projectFavorites, etc.). The exact
-        keys are tied to the workspace's plan tier and are stable but
-        not enumerated here; treat as `additionalProperties: true`.
-      type: object
     WorkspaceSettingsDtoV1:
       additionalProperties: true
       description: Workspace settings. Time Duration Format can be set by durationFormat;
@@ -23711,7 +23718,7 @@ x-clockify-generation:
   generator: scripts/gen-clockify-openapi
   sourceManifest:
     path: manifest.json
-    sha256: 3a64ee16965cb9bb7dcd2aff70ae551e1afdfbbf61da495302ba793a7882fff2
+    sha256: 8cdee71d7087959e0601bea61b175fca4f7a8cc58c8a2d6104ece96af7b34bbd
     files: 100
   sourcePrecedence:
   - live/probe findings metadata

--- a/docs/openapi/clockify-openapi.yaml
+++ b/docs/openapi/clockify-openapi.yaml
@@ -15194,8 +15194,16 @@ components:
           type: string
         archived:
           type: boolean
+        ccEmails:
+          items:
+            type: string
+          nullable: true
+          type: array
         currencyCode:
           "$ref": "#/components/schemas/Currency"
+        currencyId:
+          nullable: true
+          type: string
         email:
           format: email
           nullable: true
@@ -23703,8 +23711,8 @@ x-clockify-generation:
   generator: scripts/gen-clockify-openapi
   sourceManifest:
     path: manifest.json
-    sha256: dadb65fa9e481d85b2c30a1e5f9468ab28b3b00e712444a75d08354e770ed903
-    files: 99
+    sha256: 3a64ee16965cb9bb7dcd2aff70ae551e1afdfbbf61da495302ba793a7882fff2
+    files: 100
   sourcePrecedence:
   - live/probe findings metadata
   - realOPENAPI operation bodies

--- a/docs/openapi/sources/clockify-api-probe-lab/openapi.yaml
+++ b/docs/openapi/sources/clockify-api-probe-lab/openapi.yaml
@@ -872,6 +872,8 @@ components:
         name:          { type: string, nullable: true }
         authToken:     { type: string, description: "HMAC secret. Treat as a credential; never log." }
         enabled:       { type: boolean }
+        deliveryEnabled: { type: boolean, nullable: true }
+        planEnabled:     { type: boolean, nullable: true }
         addonId:       { type: string, nullable: true }
 
     WebhookCreate:
@@ -1129,25 +1131,35 @@ components:
              INVOICE_DETAILED, TIMEOFF_DETAILED, TIMEOFF_HOLIDAY,
              TIMEOFF_BALANCE, EXPENSE_SUMMARY]
         filter:     { $ref: "#/components/schemas/SharedReportFilter" }
-        public:     { type: boolean }
+        # Live-verified 2026-06-23: the create/update body field is `isPublic`.
+        # Sending `public` is silently ignored by the API (report stays private).
+        isPublic:   { type: boolean }
 
     SharedReport:
+      # Live-verified response shape (GET list + POST create, sandbox 2026-06-23):
+      # the wire uses `isPublic` (NOT public) and `link` (NOT url). The list adds
+      # reportAuthor/link; create adds workspaceId/userId/filter. There is no
+      # url/createdAt/updatedAt/workspace top-level field on the wire.
       type: object
       properties:
-        id:        { type: string }
-        name:      { type: string }
-        type:      { $ref: "#/components/schemas/SharedReportCreate/properties/type" }
-        filter:    { $ref: "#/components/schemas/SharedReportFilter" }
-        workspace:
-          type: object
-          properties:
-            id:   { type: string }
-            name: { type: string }
-            workspaceSettings: { $ref: "#/components/schemas/WorkspaceSettings" }
-        public:    { type: boolean }
-        url:       { type: string }
-        createdAt: { type: string, format: date-time }
-        updatedAt: { type: string, format: date-time }
+        id:          { type: string }
+        name:        { type: string }
+        type:        { $ref: "#/components/schemas/SharedReportCreate/properties/type" }
+        isPublic:    { type: boolean }
+        link:        { type: string, nullable: true }
+        reportAuthor: { type: string, nullable: true }
+        fixedDate:   { type: boolean, nullable: true }
+        visibleToUsers:
+          type: array
+          nullable: true
+          items: { type: object, additionalProperties: true }
+        visibleToUserGroups:
+          type: array
+          nullable: true
+          items: { type: object, additionalProperties: true }
+        workspaceId: { type: string, nullable: true }
+        userId:      { type: string, nullable: true }
+        filter:      { $ref: "#/components/schemas/SharedReportFilter" }
 
     SharedReportListEnvelope:
       type: object

--- a/docs/openapi/sources/clockify-api-probe-lab/openapi.yaml
+++ b/docs/openapi/sources/clockify-api-probe-lab/openapi.yaml
@@ -349,6 +349,11 @@ components:
         address:     { type: string, nullable: true }
         note:        { type: string, nullable: true }
         currencyCode: { $ref: "#/components/schemas/Currency" }
+        currencyId:  { type: string, nullable: true }
+        ccEmails:
+          type: array
+          nullable: true
+          items: { type: string }
 
     ClientCreate:
       type: object

--- a/docs/openapi/sources/manifest.json
+++ b/docs/openapi/sources/manifest.json
@@ -243,6 +243,11 @@
       "sha256": "ddb8fd2add6b097113a7b67a1b9d4731651a7fa289a8bd5b071e6df25ab75f41"
     },
     {
+      "path": "clockify-api-probe-lab/openapi-fragments/audit-log.yaml",
+      "bytes": 5981,
+      "sha256": "9c1f14648119f5794f72bfc1a439e0624b4f79e140f8804980572378772bc7c5"
+    },
+    {
       "path": "clockify-api-probe-lab/openapi-fragments/balance-a.yaml",
       "bytes": 4589,
       "sha256": "8e5a9fc33f1ad6dba5140c5b82bbcb43db81bbf45fa38df919e8b513b69891fd"
@@ -399,8 +404,8 @@
     },
     {
       "path": "clockify-api-probe-lab/openapi.yaml",
-      "bytes": 128402,
-      "sha256": "c7ff341269870f9cd3a4e3dffc44420fe1d8ee22d68d0b1b282ce124c2e28c52"
+      "bytes": 128555,
+      "sha256": "305119b09ea2b2116911a5165d85d1fefe488ebd8d9fd06cfbf8b2cdbd60894f"
     },
     {
       "path": "clockify-api-probe-lab/openapi_scheduling.yaml",

--- a/docs/openapi/sources/manifest.json
+++ b/docs/openapi/sources/manifest.json
@@ -404,8 +404,8 @@
     },
     {
       "path": "clockify-api-probe-lab/openapi.yaml",
-      "bytes": 128555,
-      "sha256": "305119b09ea2b2116911a5165d85d1fefe488ebd8d9fd06cfbf8b2cdbd60894f"
+      "bytes": 129340,
+      "sha256": "f61392a950868d48b6b9e1c28fa0e191a1cd57dcc32c563dc0377b2c0fa3339d"
     },
     {
       "path": "clockify-api-probe-lab/openapi_scheduling.yaml",

--- a/scripts/gen-clockify-openapi
+++ b/scripts/gen-clockify-openapi
@@ -167,6 +167,19 @@ def validate_source_manifest!(root)
     errors << "source manifest size mismatch #{rel}" if entry["bytes"].to_i != size
     errors << "source manifest sha256 mismatch #{rel}" if entry["sha256"].to_s != sha
   end
+
+  # Completeness (reverse) check: every consumed openapi fragment on disk must be
+  # pinned in the manifest. The forward loop above only verifies LISTED files; it
+  # never asserts that every consumed input is listed, so a new/edited fragment
+  # could otherwise slip in unhashed (e.g. audit-log.yaml did). These globs mirror
+  # the generator's own probe-fragment globs below.
+  pinned = Array(manifest["files"]).map { |entry| entry["path"].to_s }
+  ["clockify-api-probe-lab/openapi-fragments", "clockify-api-probe-lab/openapi-fragments-v3"].each do |dir|
+    Dir[File.join(root, dir, "*.yaml")].sort.each do |abs|
+      rel = abs.sub(%r{\A#{Regexp.escape(root)}/?}, "")
+      errors << "source consumed but not pinned in manifest: #{rel}" unless pinned.include?(rel)
+    end
+  end
   abort(errors.join("\n")) unless errors.empty?
 
   {


### PR DESCRIPTION
## What

Two source-integrity fixes to the OpenAPI generator, found in a trust-nothing audit cross-checked against the live Clockify sandbox.

### 1. Restore `Client.ccEmails` + `Client.currencyId`
The generated `Client` response schema dropped both fields. They are **returned by the live API** (`GET /clients`) and present in the official `ClientDtoV1`. Root cause: `clockify-api-probe-lab/openapi.yaml` declares a thin `Client` schema that wins the **first-writer** schema-name race over the richer `clients-a/b.yaml` fragments, which then become orphans and are pruned. Fix: add the two nullable fields to the source schema. **Op count unchanged (169).**

### 2. Pin `audit-log.yaml` + add a manifest completeness check
`clockify-api-probe-lab/openapi-fragments/audit-log.yaml` is git-tracked and consumed by the generator but was **not pinned** in `manifest.json` — its content could change with no sha mismatch (`validate_source_manifest!` was forward-only). Pin it, and add a reverse completeness check so any consumed openapi fragment that is not pinned aborts generation.

## Proof
- `make gen-openapi` → 169 ops, `ccEmails`+`currencyId` present.
- Transiently unpinning `audit-log.yaml` → `gen-openapi` aborts exit 1 with `source consumed but not pinned`.
- `make perfect` → **exit 0** (race tests, api-parity 156, coverage-dashboard 156, all drift gates, `git diff --check`).

Downstream: `apet97/clockify-ts-sdk` re-snapshots this canonical spec (companion PR) so the generated TS `Client` type regains both fields.

https://claude.ai/code/session_01VKusetEthSVDZygexhaqNa